### PR TITLE
Miami institutional outreach portfolio pages

### DIFF
--- a/src/app/(main)/artist-sustainability/page.tsx
+++ b/src/app/(main)/artist-sustainability/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next';
+import { ArtistSustainabilityClient } from '@/components/institutions/ArtistSustainabilityClient';
+import { artistSustainabilityPage } from '@/content/institutions/artistSustainability';
+
+const { meta } = artistSustainabilityPage;
+
+export const metadata: Metadata = {
+  title: meta.title,
+  description: meta.description,
+  robots: {
+    index: false,
+    follow: true,
+  },
+  openGraph: {
+    title: meta.title,
+    description: meta.description,
+    type: 'website',
+    url: meta.url,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: meta.title,
+    description: meta.description,
+  },
+};
+
+export default function ArtistSustainabilityPage() {
+  return <ArtistSustainabilityClient />;
+}

--- a/src/app/(main)/bakehouse/page.tsx
+++ b/src/app/(main)/bakehouse/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import { BakehousePageClient } from '@/components/institutions/BakehousePageClient';
+import { bakehousePage } from '@/content/institutions/bakehouse';
+
+const { meta } = bakehousePage;
+
+export const metadata: Metadata = {
+  title: meta.title,
+  description: meta.description,
+  openGraph: {
+    title: meta.title,
+    description: meta.description,
+    type: 'website',
+    url: meta.url,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: meta.title,
+    description: meta.description,
+  },
+};
+
+export default function BakehousePage() {
+  return <BakehousePageClient />;
+}

--- a/src/app/(main)/institutions/page.tsx
+++ b/src/app/(main)/institutions/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import { InstitutionsHubClient } from '@/components/institutions/InstitutionsHubClient';
+import { institutionsHub } from '@/content/institutions/hub';
+
+const { meta } = institutionsHub;
+
+export const metadata: Metadata = {
+  title: meta.title,
+  description: meta.description,
+  openGraph: {
+    title: meta.title,
+    description: meta.description,
+    type: 'website',
+    url: meta.url,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: meta.title,
+    description: meta.description,
+  },
+};
+
+export default function InstitutionsPage() {
+  return <InstitutionsHubClient />;
+}

--- a/src/app/(main)/oolite-arts/page.tsx
+++ b/src/app/(main)/oolite-arts/page.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from 'next';
+import OoliteCaseStudy from '@/components/case-studies/oolite/OoliteCaseStudy';
+import { OOLITE_ARTS_CASE_STUDY } from '@/content/oolite-arts/case-study';
+
+const { meta } = OOLITE_ARTS_CASE_STUDY;
+
+export const metadata: Metadata = {
+  title: meta.title,
+  description: meta.description,
+  openGraph: {
+    title: meta.title,
+    description: meta.description,
+    type: 'article',
+    url: meta.url,
+    images: [
+      {
+        url: meta.ogImage,
+        width: 1030,
+        height: 579,
+        alt: 'Oolite Arts Digital Lab',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: meta.title,
+    description: meta.description,
+    images: [meta.ogImage],
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+};
+
+export default function OoliteArtsPage() {
+  return <OoliteCaseStudy />;
+}

--- a/src/app/(main)/workshops/page.tsx
+++ b/src/app/(main)/workshops/page.tsx
@@ -10,9 +10,9 @@ const WorkshopHubClient = dynamic(() => import('@/components/page/WorkshopClient
   ),
 })
 
-const title = 'Art & Technology Workshops | Talk Hub — Moises Sanabria & Fabiola Larios'
+const title = 'Art & Technology Workshops — Bookable Institutional Offerings | Moises Sanabria'
 const description =
-  'Automation workshop + partnerships. Artist task automation, institutional consulting, and workshops by Moises Sanabria (Technical Director of Digital, Oolite Arts) and Fabiola Larios.'
+  'Three bookable offerings: Vibe Coding and Digital Presence, AI and Automation for the Artist Studio, and Creative Technology Prototyping—plus deeper workshop programs from Oolite Arts practice.'
 
 export const metadata: Metadata = {
   title,

--- a/src/components/case-studies/oolite/AssetNeeded.tsx
+++ b/src/components/case-studies/oolite/AssetNeeded.tsx
@@ -1,0 +1,44 @@
+import type { NeededAsset } from '@/content/oolite-arts/case-study';
+
+export function AssetNeeded({
+  asset,
+  tone = 'light',
+}: {
+  asset: NeededAsset;
+  tone?: 'light' | 'dark';
+}) {
+  const dark = tone === 'dark';
+  return (
+    <div
+      role="status"
+      className={
+        dark
+          ? 'border border-dashed border-white/35 bg-white/10 text-white p-3 sm:p-4 text-left'
+          : 'border border-dashed border-amber-700/50 bg-amber-50 text-amber-950 p-3 sm:p-4 text-left'
+      }
+    >
+      <p
+        className={`font-mono text-[10px] sm:text-[11px] tracking-[0.16em] uppercase mb-1.5 ${
+          dark ? 'text-[#E10600]' : 'text-amber-800'
+        }`}
+      >
+        Asset needed
+      </p>
+      <p className="text-sm font-medium mb-2">{asset.name}</p>
+      <dl className={`space-y-1 text-xs ${dark ? 'text-white/75' : 'text-amber-900/80'}`}>
+        <div className="grid grid-cols-[5.5rem_1fr] gap-2">
+          <dt className="font-mono uppercase tracking-wider">Format</dt>
+          <dd>{asset.preferred}</dd>
+        </div>
+        <div className="grid grid-cols-[5.5rem_1fr] gap-2">
+          <dt className="font-mono uppercase tracking-wider">Folder</dt>
+          <dd className="font-mono break-all">{asset.folder}</dd>
+        </div>
+        <div className="grid grid-cols-[5.5rem_1fr] gap-2">
+          <dt className="font-mono uppercase tracking-wider">Record</dt>
+          <dd className="font-mono break-all">{asset.record}</dd>
+        </div>
+      </dl>
+    </div>
+  );
+}

--- a/src/components/case-studies/oolite/BeforeAfterSlider.tsx
+++ b/src/components/case-studies/oolite/BeforeAfterSlider.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useCallback, useId, useRef, useState, type KeyboardEvent, type PointerEvent } from 'react';
+import Image from 'next/image';
+import { AssetNeeded } from './AssetNeeded';
+import type { NeededAsset } from '@/content/oolite-arts/case-study';
+
+type Side = { src: string; alt: string } | null;
+
+type Props = {
+  beforeLabel: string;
+  afterLabel: string;
+  before: Side;
+  after: Side;
+  needed: NeededAsset;
+};
+
+export function BeforeAfterSlider({
+  beforeLabel,
+  afterLabel,
+  before,
+  after,
+  needed,
+}: Props) {
+  const [position, setPosition] = useState(50);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const labelId = useId();
+
+  const updateFromClientX = useCallback((clientX: number) => {
+    const el = trackRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const next = ((clientX - rect.left) / rect.width) * 100;
+    setPosition(Math.min(100, Math.max(0, next)));
+  }, []);
+
+  const onPointerDown = (e: PointerEvent<HTMLDivElement>) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    updateFromClientX(e.clientX);
+  };
+
+  const onPointerMove = (e: PointerEvent<HTMLDivElement>) => {
+    if (!e.currentTarget.hasPointerCapture(e.pointerId)) return;
+    updateFromClientX(e.clientX);
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      setPosition((p) => Math.max(0, p - 5));
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      setPosition((p) => Math.min(100, p + 5));
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setPosition(0);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setPosition(100);
+    }
+  };
+
+  if (!before || !after) {
+    return (
+      <div className="space-y-3">
+        <div className="relative aspect-[16/10] bg-neutral-200 overflow-hidden">
+          {after ? (
+            <Image src={after.src} alt={after.alt} fill className="object-cover" sizes="100vw" />
+          ) : before ? (
+            <Image src={before.src} alt={before.alt} fill className="object-cover" sizes="100vw" />
+          ) : null}
+          <div className="absolute inset-0 bg-black/35 flex items-end p-4 sm:p-6">
+            <p className="text-white text-sm sm:text-base max-w-md">
+              Matched before/after media required for the interactive slider. Showing available lab
+              documentation until the pair is ready.
+            </p>
+          </div>
+        </div>
+        <AssetNeeded asset={needed} />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div
+        ref={trackRef}
+        role="slider"
+        aria-labelledby={labelId}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(position)}
+        aria-valuetext={`${Math.round(position)} percent ${afterLabel} revealed`}
+        tabIndex={0}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onKeyDown={onKeyDown}
+        className="relative aspect-[16/10] overflow-hidden bg-neutral-200 cursor-ew-resize touch-none select-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
+      >
+        <Image src={after.src} alt={after.alt} fill className="object-cover" sizes="100vw" priority={false} />
+        <div
+          className="absolute inset-0 overflow-hidden"
+          style={{ clipPath: `inset(0 ${100 - position}% 0 0)` }}
+        >
+          <Image src={before.src} alt={before.alt} fill className="object-cover" sizes="100vw" />
+        </div>
+        <div
+          className="absolute inset-y-0 w-0.5 bg-white shadow-[0_0_0_1px_rgba(0,0,0,0.35)]"
+          style={{ left: `${position}%` }}
+        >
+          <span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 h-10 w-10 rounded-full bg-white border border-black/20 flex items-center justify-center text-xs font-mono">
+            ↔
+          </span>
+        </div>
+        <span className="absolute top-3 left-3 font-mono text-[10px] tracking-[0.14em] uppercase bg-black/70 text-white px-2 py-1">
+          {beforeLabel}
+        </span>
+        <span className="absolute top-3 right-3 font-mono text-[10px] tracking-[0.14em] uppercase bg-black/70 text-white px-2 py-1">
+          {afterLabel}
+        </span>
+      </div>
+      <p id={labelId} className="sr-only">
+        Before and after comparison slider. Use arrow keys to adjust.
+      </p>
+    </div>
+  );
+}

--- a/src/components/case-studies/oolite/LabSystemMap.tsx
+++ b/src/components/case-studies/oolite/LabSystemMap.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState } from 'react';
+import { OOLITE_ARTS_CASE_STUDY } from '@/content/oolite-arts/case-study';
+
+const layers = OOLITE_ARTS_CASE_STUDY.systemLayers;
+type LayerId = (typeof layers)[number]['id'];
+
+export function LabSystemMap() {
+  const [activeId, setActiveId] = useState<LayerId>(layers[0].id);
+  const active = layers.find((l) => l.id === activeId) ?? layers[0];
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-12 gap-8 lg:gap-10">
+      <div className="lg:col-span-4 flex flex-col gap-2" role="tablist" aria-label="Lab system layers">
+        {layers.map((layer, i) => {
+          const selected = layer.id === activeId;
+          return (
+            <button
+              key={layer.id}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              id={`layer-tab-${layer.id}`}
+              aria-controls={`layer-panel-${layer.id}`}
+              onClick={() => setActiveId(layer.id)}
+              className={`text-left border px-4 py-3 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black ${
+                selected
+                  ? 'bg-black text-white border-black'
+                  : 'bg-white border-black/15 hover:border-black/40'
+              }`}
+            >
+              <span className="font-mono text-[10px] tracking-[0.16em] uppercase opacity-70">
+                Layer {String(i + 1).padStart(2, '0')}
+              </span>
+              <span className="block font-['MoMA_Sans'] text-xl font-bold mt-1">
+                {layer.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div
+        className="lg:col-span-8 border border-black/10 bg-white p-6 sm:p-8"
+        role="tabpanel"
+        id={`layer-panel-${active.id}`}
+        aria-labelledby={`layer-tab-${active.id}`}
+      >
+        <h3 className="font-['MoMA_Sans'] text-2xl sm:text-3xl font-bold mb-6">
+          {active.label}
+        </h3>
+        <dl className="space-y-5 text-sm sm:text-base">
+          {(
+            [
+              ['Problem', active.problem],
+              ['Intervention', active.intervention],
+              ['Outcome', active.outcome],
+              ['Evidence', active.evidence],
+            ] as const
+          ).map(([label, value]) => (
+            <div key={label} className="grid grid-cols-1 sm:grid-cols-[8rem_1fr] gap-1 sm:gap-4 border-t border-black/10 pt-4">
+              <dt className="font-mono text-[11px] tracking-[0.12em] uppercase text-neutral-500">
+                {label}
+              </dt>
+              <dd className="text-neutral-800 leading-relaxed">{value}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/src/components/case-studies/oolite/OoliteCaseStudy.tsx
+++ b/src/components/case-studies/oolite/OoliteCaseStudy.tsx
@@ -510,6 +510,17 @@ export default function OoliteCaseStudy() {
           <p className="font-mono text-xs text-neutral-500">
             Last updated {C.credits.lastUpdated} · {C.credits.phaseNote}
           </p>
+          <div className="mt-10 flex flex-wrap gap-x-6 gap-y-2 border-t border-black/10 pt-8 text-sm">
+            <Link href="/institutions" className="font-medium underline underline-offset-4">
+              Institutions hub
+            </Link>
+            <Link href="/bakehouse" className="font-medium underline underline-offset-4">
+              Bakehouse digital systems
+            </Link>
+            <Link href="/workshops" className="font-medium underline underline-offset-4">
+              Bookable workshops
+            </Link>
+          </div>
         </div>
       </section>
     </main>

--- a/src/components/case-studies/oolite/OoliteCaseStudy.tsx
+++ b/src/components/case-studies/oolite/OoliteCaseStudy.tsx
@@ -1,0 +1,517 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { OOLITE_ARTS_CASE_STUDY } from '@/content/oolite-arts/case-study';
+import { AssetNeeded } from './AssetNeeded';
+import { BeforeAfterSlider } from './BeforeAfterSlider';
+import { LabSystemMap } from './LabSystemMap';
+import { VisibleInvisibleToggle } from './VisibleInvisibleToggle';
+
+const C = OOLITE_ARTS_CASE_STUDY;
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="font-mono text-[11px] sm:text-xs tracking-[0.18em] uppercase text-neutral-500 mb-3">
+      {children}
+    </p>
+  );
+}
+
+function ClassArchive() {
+  const [topic, setTopic] = useState<string>('all');
+  const topics = useMemo(() => {
+    const set = new Set<string>();
+    C.classes.forEach((c) => c.topics.forEach((t) => set.add(t)));
+    return ['all', ...Array.from(set)];
+  }, []);
+
+  const filtered =
+    topic === 'all'
+      ? C.classes
+      : C.classes.filter((c) => (c.topics as readonly string[]).includes(topic));
+
+  return (
+    <div>
+      <div className="flex flex-wrap gap-2 mb-8" role="group" aria-label="Filter classes by topic">
+        {topics.map((t) => (
+          <button
+            key={t}
+            type="button"
+            aria-pressed={topic === t}
+            onClick={() => setTopic(t)}
+            className={`font-mono text-[11px] tracking-[0.12em] uppercase px-3 py-2 border transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black ${
+              topic === t
+                ? 'bg-black text-white border-black'
+                : 'bg-white border-black/20 hover:border-black/50'
+            }`}
+          >
+            {t === 'all' ? 'All' : t.replace(/-/g, ' ')}
+          </button>
+        ))}
+      </div>
+
+      <div className="space-y-10">
+        {filtered.map((cls) => (
+          <article
+            key={cls.id}
+            className="grid grid-cols-1 lg:grid-cols-12 gap-6 border-t border-black/10 pt-8"
+          >
+            <div className="lg:col-span-4">
+              <div className="relative aspect-[16/10] bg-neutral-200 overflow-hidden mb-3">
+                {cls.image ? (
+                  <Image
+                    src={cls.image.src}
+                    alt={cls.image.alt}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 1024px) 100vw, 33vw"
+                  />
+                ) : (
+                  <div className="absolute inset-0 flex items-center justify-center p-4">
+                    <p className="font-mono text-[11px] tracking-[0.14em] uppercase text-neutral-500 text-center">
+                      Class photo pending
+                    </p>
+                  </div>
+                )}
+              </div>
+              {cls.needed && <AssetNeeded asset={cls.needed} />}
+            </div>
+            <div className="lg:col-span-8">
+              <p className="font-mono text-[11px] tracking-[0.12em] uppercase text-neutral-500 mb-2">
+                {cls.format} · {cls.level}
+                {cls.capacity != null ? ` · Cap ${cls.capacity}` : ''}
+              </p>
+              <h3 className="font-['MoMA_Sans'] text-2xl sm:text-3xl font-bold mb-2">
+                {cls.title}
+              </h3>
+              <p className="text-sm text-neutral-600 mb-4">{cls.dateLabel}</p>
+              <p className="text-neutral-800 leading-relaxed mb-4">{cls.summary}</p>
+              <p className="text-sm text-neutral-600 mb-3">
+                Instructors: {cls.instructors.join(' · ')}
+              </p>
+              {cls.learningOutcomes.length > 0 && (
+                <ul className="space-y-2 mb-4">
+                  {cls.learningOutcomes.map((o) => (
+                    <li key={o} className="text-sm text-neutral-700 flex gap-2">
+                      <span className="text-neutral-400">·</span>
+                      <span>{o}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              <a
+                href={cls.sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-xs tracking-[0.1em] uppercase underline underline-offset-4 hover:text-neutral-600"
+              >
+                Public source →
+              </a>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function OoliteCaseStudy() {
+  return (
+    <main className="min-h-screen bg-[#F7F8FA] text-black pt-24 sm:pt-28">
+      {/* Disclaimer strip */}
+      <div className="border-y border-black/10 bg-white">
+        <div className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11 py-3">
+          <p className="font-mono text-[10px] sm:text-[11px] tracking-[0.08em] text-neutral-600 leading-relaxed">
+            {C.overview.disclaimer}
+          </p>
+        </div>
+      </div>
+
+      {/* Hero */}
+      <section className="relative">
+        <div className="relative aspect-[16/9] sm:aspect-[21/9] max-h-[70vh] bg-neutral-300 overflow-hidden">
+          <Image
+            src={C.overview.heroImage.src}
+            alt={C.overview.heroImage.alt}
+            fill
+            priority
+            className="object-cover"
+            sizes="100vw"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/75 via-black/35 to-black/20" />
+          <div className="absolute inset-0 flex flex-col justify-end p-6 sm:p-10 lg:p-14 max-w-7xl mx-auto w-full">
+            <p className="font-mono text-[11px] tracking-[0.2em] uppercase text-white/80 mb-3">
+              Oolite Arts Digital Lab · Miami Beach · {C.overview.period}
+            </p>
+            <h1 className="font-['MoMA_Sans'] text-3xl sm:text-5xl md:text-6xl lg:text-7xl font-bold text-white tracking-tight leading-[0.95] max-w-4xl mb-4">
+              {C.overview.title}
+            </h1>
+            <p className="text-white/90 text-base sm:text-xl max-w-2xl mb-2">
+              {C.overview.supportingLine}
+            </p>
+            <p className="font-mono text-[10px] text-white/60 tracking-wide">
+              Phase 1 · Static hero · 360° immersive view pending
+            </p>
+          </div>
+        </div>
+        <div className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11 py-4">
+          <AssetNeeded asset={C.overview.neededHero360} />
+        </div>
+      </section>
+
+      {/* Opening + credits */}
+      <section className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11 py-14 sm:py-20">
+        <p className="text-xl sm:text-2xl md:text-3xl leading-snug text-neutral-800 max-w-4xl mb-8">
+          {C.overview.subtitle}
+        </p>
+        <blockquote className="border-l-2 border-[#E10600] pl-5 mb-10 max-w-3xl">
+          <p className="text-lg sm:text-xl leading-snug text-black">
+            {C.overview.thesis}
+          </p>
+        </blockquote>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 border-t border-black/10 pt-8 mb-8">
+          {C.overview.credits.map((c) => (
+            <div key={c.name}>
+              <p className="font-mono text-[11px] tracking-[0.12em] uppercase text-neutral-500 mb-1">
+                {c.role}
+              </p>
+              <p className="font-['MoMA_Sans'] text-xl font-bold">{c.name}</p>
+            </div>
+          ))}
+        </div>
+        <p className="text-sm text-neutral-600 mb-6">{C.overview.collaboration}</p>
+        <p className="text-sm text-neutral-500">
+          Public lab hours: {C.overview.publicLab.hours} · {C.overview.publicLab.languages} ·
+          Support acknowledged publicly: {C.overview.publicLab.support}.{' '}
+          <a
+            href={C.overview.publicLab.sourceUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2"
+          >
+            {C.overview.publicLab.sourceLabel}
+          </a>
+        </p>
+      </section>
+
+      {/* Narrative arc */}
+      <section className="border-t border-black/10 bg-white py-14 sm:py-20">
+        <div className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11">
+          <SectionLabel>Narrative arc</SectionLabel>
+          <h2 className="font-['MoMA_Sans'] text-3xl sm:text-4xl font-bold tracking-tight mb-4 max-w-3xl">
+            {C.institutionalQuestion.title}
+          </h2>
+          <p className="text-neutral-700 max-w-2xl mb-10">{C.institutionalQuestion.lead}</p>
+          <ol className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
+            {C.narrativeArc.map((step, i) => (
+              <li key={step.title} className="border-t border-black pt-4">
+                <p className="font-mono text-[11px] tracking-[0.14em] text-neutral-400 mb-2">
+                  {String(i + 1).padStart(2, '0')}
+                </p>
+                <h3 className="font-['MoMA_Sans'] text-xl font-bold mb-2">{step.title}</h3>
+                <p className="text-sm text-neutral-700 leading-relaxed">{step.body}</p>
+              </li>
+            ))}
+          </ol>
+          <ul className="flex flex-wrap gap-3">
+            {C.institutionalQuestion.statements.map((s) => (
+              <li
+                key={s}
+                className="font-mono text-[11px] sm:text-xs tracking-[0.08em] uppercase border border-black/15 bg-[#F7F8FA] px-3 py-2"
+              >
+                {s}
+              </li>
+            ))}
+          </ul>
+          <p className="mt-10 text-lg sm:text-xl max-w-3xl text-neutral-800">
+            {C.overview.oneSentence}
+          </p>
+        </div>
+      </section>
+
+      {/* Before / After */}
+      <section id="before-after" className="border-t border-black/10 py-14 sm:py-20">
+        <div className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11">
+          <SectionLabel>Transformation</SectionLabel>
+          <h2 className="font-['MoMA_Sans'] text-3xl sm:text-4xl font-bold tracking-tight mb-4">
+            {C.beforeAfter.title}
+          </h2>
+          <p className="text-neutral-700 max-w-2xl mb-8">{C.beforeAfter.body}</p>
+          {C.beforeAfter.pairs.map((pair) => (
+            <BeforeAfterSlider
+              key={pair.id}
+              beforeLabel={pair.beforeLabel}
+              afterLabel={pair.afterLabel}
+              before={pair.before}
+              after={pair.after}
+              needed={pair.needed}
+            />
+          ))}
+        </div>
+      </section>
+
+      {/* System map */}
+      <section id="system" className="border-t border-black/10 bg-white py-14 sm:py-20">
+        <div className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11">
+          <SectionLabel>What we built · five layers</SectionLabel>
+          <h2 className="font-['MoMA_Sans'] text-3xl sm:text-4xl font-bold tracking-tight mb-3">
+            Lab as connected system
+          </h2>
+          <p className="text-neutral-700 max-w-2xl mb-10">
+            Click a layer to read the problem, intervention, evidence, and outcome.
+          </p>
+          <LabSystemMap />
+        </div>
+      </section>
+
+      {/* Resin workflow */}
+      <section id="resin" className="border-t border-black/10 py-14 sm:py-20">
+        <div className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11">
+          <SectionLabel>Fabrication knowledge</SectionLabel>
+          <h2 className="font-['MoMA_Sans'] text-3xl sm:text-4xl font-bold tracking-tight mb-4">
+            {C.resinWorkflow.title}
+          </h2>
+          <p className="text-neutral-700 max-w-2xl mb-8">{C.resinWorkflow.lead}</p>
+          <ol className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-7 gap-3 mb-8">
+            {C.resinWorkflow.steps.map((step, i) => (
+              <li
+                key={step.id}
+                className="border border-black/15 bg-white p-3 min-h-[6.5rem] flex flex-col"
+              >
+                <span className="font-mono text-[10px] tracking-[0.14em] text-neutral-400 mb-2">
+                  {String(i + 1).padStart(2, '0')}
+                </span>
+                <span className="text-sm font-medium leading-snug mt-auto">{step.label}</span>
+              </li>
+            ))}
+          </ol>
+          <div className="mb-6">
+            <p className="font-mono text-[11px] tracking-[0.12em] uppercase text-neutral-500 mb-3">
+              Institutional knowledge required
+            </p>
+            <ul className="flex flex-wrap gap-2">
+              {C.resinWorkflow.institutionalKnowledge.map((k) => (
+                <li
+                  key={k}
+                  className="text-sm border border-black/15 px-3 py-1.5 bg-white"
+                >
+                  {k}
+                </li>
+              ))}
+            </ul>
+          </div>
+          <AssetNeeded asset={C.resinWorkflow.needed} />
+        </div>
+      </section>
+
+      {/* Classes */}
+      <section id="classes" className="border-t border-black/10 bg-white py-14 sm:py-20">
+        <div className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11">
+          <SectionLabel>Classes as a living program</SectionLabel>
+          <h2 className="font-['MoMA_Sans'] text-3xl sm:text-4xl font-bold tracking-tight mb-3">
+            Featured Digital Lab workshops
+          </h2>
+          <p className="text-neutral-700 max-w-2xl mb-8">
+            Records grounded in Oolite Arts public class pages. Photo galleries expand as assets arrive.
+          </p>
+          <ClassArchive />
+        </div>
+      </section>
+
+      {/* Artist support */}
+      <section id="artists" className="border-t border-black/10 py-14 sm:py-20">
+        <div className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11">
+          <SectionLabel>Helping artists</SectionLabel>
+          <h2 className="font-['MoMA_Sans'] text-3xl sm:text-4xl font-bold tracking-tight mb-3">
+            Need → obstacle → support → result
+          </h2>
+          <p className="text-neutral-700 max-w-2xl mb-10">
+            Phase 1 shows support patterns drawn from public curriculum—not named artists.
+            Consented mini case studies will replace these archetypes.
+          </p>
+          <div className="space-y-8">
+            {C.artistStories.map((story) => (
+              <article
+                key={story.id}
+                className="border border-black/10 bg-white p-6 sm:p-8"
+              >
+                <p className="font-mono text-[11px] tracking-[0.12em] uppercase text-[#E10600] mb-3">
+                  {story.anonymizedLabel}
+                </p>
+                <dl className="space-y-4 text-sm sm:text-base">
+                  {(
+                    [
+                      ['Wanted', story.wanted],
+                      ['Obstacle', story.obstacle],
+                      ['Support', story.support],
+                      ['Result', story.result],
+                      ['Next', story.next],
+                    ] as const
+                  ).map(([label, value]) => (
+                    <div
+                      key={label}
+                      className="grid grid-cols-1 sm:grid-cols-[7rem_1fr] gap-1 sm:gap-4"
+                    >
+                      <dt className="font-mono text-[11px] tracking-[0.12em] uppercase text-neutral-500">
+                        {label}
+                      </dt>
+                      <dd className="text-neutral-800 leading-relaxed">{value}</dd>
+                    </div>
+                  ))}
+                </dl>
+                <div className="mt-6">
+                  <AssetNeeded asset={story.needed} />
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Invisible infrastructure — signature */}
+      <section id="infrastructure" className="border-t border-black/10 bg-black text-white py-14 sm:py-20">
+        <div className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11">
+          <p className="font-mono text-[11px] sm:text-xs tracking-[0.18em] uppercase text-[#E10600] mb-3">
+            Signature section
+          </p>
+          <h2 className="font-['MoMA_Sans'] text-3xl sm:text-4xl md:text-5xl font-bold tracking-tight mb-4">
+            {C.visibleInvisible.title}
+          </h2>
+          <p className="text-white/75 max-w-2xl mb-10 text-lg leading-relaxed">
+            {C.visibleInvisible.lead}
+          </p>
+          <VisibleInvisibleToggle tone="dark" />
+        </div>
+      </section>
+
+      {/* Outcomes */}
+      <section id="outcomes" className="border-t border-black/10 bg-white py-14 sm:py-20">
+        <div className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11">
+          <SectionLabel>Outcomes dashboard</SectionLabel>
+          <h2 className="font-['MoMA_Sans'] text-3xl sm:text-4xl font-bold tracking-tight mb-3">
+            Verified facts only
+          </h2>
+          <p className="text-neutral-600 text-sm mb-10 max-w-2xl">{C.metrics.asOfNote}</p>
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            {C.metrics.items.map((m) => (
+              <div
+                key={m.id}
+                className={`border p-4 sm:p-5 min-h-[8rem] flex flex-col ${
+                  m.verified
+                    ? 'border-black/15 bg-[#F7F8FA]'
+                    : 'border-dashed border-neutral-300 bg-white'
+                }`}
+              >
+                <p className="font-mono text-[10px] tracking-[0.14em] uppercase text-neutral-500 mb-3">
+                  {m.verified ? 'Verified' : 'Pending verification'}
+                </p>
+                <p className="font-['MoMA_Sans'] text-3xl sm:text-4xl font-bold mb-1">
+                  {m.value ?? '—'}
+                </p>
+                <p className="text-sm font-medium mb-1">{m.label}</p>
+                <p className="text-xs text-neutral-500 mt-auto">{m.detail}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Framework */}
+      <section id="framework" className="border-t border-black/10 py-14 sm:py-20">
+        <div className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11">
+          <SectionLabel>Reusable model</SectionLabel>
+          <h2 className="font-['MoMA_Sans'] text-3xl sm:text-4xl font-bold tracking-tight mb-10">
+            {C.framework.title}
+          </h2>
+          <ol className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-6 mb-14">
+            {C.framework.steps.map((step) => (
+              <li key={step.n} className="border-t-2 border-black pt-4">
+                <p className="font-mono text-xs tracking-[0.16em] text-neutral-400 mb-2">
+                  {step.n}
+                </p>
+                <h3 className="font-['MoMA_Sans'] text-xl font-bold mb-2">{step.title}</h3>
+                <p className="text-sm text-neutral-700 leading-relaxed">{step.body}</p>
+              </li>
+            ))}
+          </ol>
+
+          <div className="bg-black text-white p-8 sm:p-12">
+            <h3 className="font-['MoMA_Sans'] text-2xl sm:text-3xl md:text-4xl font-bold tracking-tight leading-tight max-w-3xl mb-8">
+              {C.framework.cta.headline}
+            </h3>
+            <div className="flex flex-wrap gap-3">
+              {C.framework.cta.buttons.map((btn, i) => (
+                <Link
+                  key={btn.href + btn.label}
+                  href={btn.href}
+                  className={
+                    i === 0
+                      ? 'inline-flex items-center bg-white text-black px-5 py-3 text-sm font-medium hover:bg-[#E10600] hover:text-white transition-colors'
+                      : 'inline-flex items-center border border-white/40 px-5 py-3 text-sm font-medium hover:bg-white/10 transition-colors'
+                  }
+                >
+                  {btn.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Credits */}
+      <section id="credits" className="border-t border-black/10 bg-white py-14 sm:py-20">
+        <div className="max-w-7xl mx-auto px-6 sm:px-10 lg:px-11">
+          <SectionLabel>Credits and archive notes</SectionLabel>
+          <h2 className="font-['MoMA_Sans'] text-3xl sm:text-4xl font-bold tracking-tight mb-8">
+            Attribution
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-8 mb-10">
+            {C.credits.roles.map((r) => (
+              <div key={r.name}>
+                <p className="font-['MoMA_Sans'] text-xl font-bold">{r.name}</p>
+                <p className="text-sm text-neutral-600 mt-1 mb-2">{r.role}</p>
+                <a
+                  href={r.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-mono text-xs tracking-[0.1em] uppercase underline underline-offset-4"
+                >
+                  {r.website.replace(/^https?:\/\//, '')} →
+                </a>
+              </div>
+            ))}
+          </div>
+          <p className="text-sm text-neutral-700 mb-2">
+            Developed in collaboration with: {C.credits.collective}
+          </p>
+          <p className="text-sm text-neutral-600 mb-6">{C.credits.funderNote}</p>
+          <p className="text-sm text-neutral-600 mb-8 max-w-3xl">{C.overview.disclaimer}</p>
+
+          <p className="font-mono text-[11px] tracking-[0.12em] uppercase text-neutral-500 mb-3">
+            Sources
+          </p>
+          <ul className="space-y-2 mb-8">
+            {C.credits.sources.map((s) => (
+              <li key={s.href}>
+                <a
+                  href={s.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm underline underline-offset-2 hover:text-neutral-600"
+                >
+                  {s.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+          <p className="font-mono text-xs text-neutral-500">
+            Last updated {C.credits.lastUpdated} · {C.credits.phaseNote}
+          </p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/case-studies/oolite/VisibleInvisibleToggle.tsx
+++ b/src/components/case-studies/oolite/VisibleInvisibleToggle.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useState } from 'react';
+import { AssetNeeded } from './AssetNeeded';
+import { OOLITE_ARTS_CASE_STUDY } from '@/content/oolite-arts/case-study';
+
+const data = OOLITE_ARTS_CASE_STUDY.visibleInvisible;
+
+export function VisibleInvisibleToggle({ tone = 'light' }: { tone?: 'light' | 'dark' }) {
+  const [mode, setMode] = useState<'visible' | 'invisible'>('visible');
+  const items = mode === 'visible' ? data.visible : data.invisible;
+  const isDark = tone === 'dark';
+
+  return (
+    <div>
+      <div
+        className={`inline-flex border p-1 mb-8 ${isDark ? 'border-white/30' : 'border-black/20'}`}
+        role="group"
+        aria-label="Visible or invisible infrastructure"
+      >
+        {(
+          [
+            ['visible', 'What visitors saw'],
+            ['invisible', 'What made it possible'],
+          ] as const
+        ).map(([key, label]) => (
+          <button
+            key={key}
+            type="button"
+            aria-pressed={mode === key}
+            onClick={() => setMode(key)}
+            className={`px-4 py-2.5 text-sm font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ${
+              isDark
+                ? 'focus-visible:outline-white'
+                : 'focus-visible:outline-black'
+            } ${
+              mode === key
+                ? key === 'invisible'
+                  ? 'bg-[#E10600] text-white'
+                  : isDark
+                    ? 'bg-white text-black'
+                    : 'bg-black text-white'
+                : isDark
+                  ? 'bg-transparent text-white/80 hover:bg-white/10'
+                  : 'bg-transparent text-neutral-700 hover:bg-black/5'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <ul className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4 mb-8">
+        {items.map((item) => (
+          <li
+            key={item}
+            className={`border px-4 py-5 min-h-[5.5rem] flex items-end ${
+              mode === 'invisible'
+                ? isDark
+                  ? 'border-[#E10600]/50 bg-[#E10600]/15'
+                  : 'border-[#E10600]/40 bg-[#E10600]/5'
+                : isDark
+                  ? 'border-white/20 bg-white/5'
+                  : 'border-black/15 bg-white'
+            }`}
+          >
+            <span className="font-['MoMA_Sans'] text-lg sm:text-xl font-bold leading-tight">
+              {item}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <AssetNeeded asset={data.neededDocs} tone={tone} />
+    </div>
+  );
+}
+

--- a/src/components/institutions/ArtistSustainabilityClient.tsx
+++ b/src/components/institutions/ArtistSustainabilityClient.tsx
@@ -1,0 +1,277 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { Mail, Calendar } from 'lucide-react';
+import { artistSustainabilityPage } from '@/content/institutions/artistSustainability';
+import { track } from '@/lib/analytics';
+import {
+  InstContainer,
+  InstPageShell,
+  InstSectionLabel,
+} from '@/components/institutions/InstitutionalUi';
+import { cn } from '@/lib/utils';
+
+const P = artistSustainabilityPage;
+
+const statusStyles = {
+  demonstrated: 'border-emerald-300 bg-emerald-50 text-emerald-900',
+  transferable: 'border-sky-300 bg-sky-50 text-sky-900',
+  todo: 'border-stone-300 bg-stone-100 text-stone-700',
+} as const;
+
+const statusLabels = {
+  demonstrated: 'Demonstrated',
+  transferable: 'Transferable',
+  todo: 'Pending',
+} as const;
+
+export function ArtistSustainabilityClient() {
+  const [activeId, setActiveId] = useState<string>(P.nav[0]?.id ?? 'overview');
+
+  useEffect(() => {
+    const ids = P.nav.map((n) => n.id);
+    const onScroll = () => {
+      let current = ids[0];
+      for (const id of ids) {
+        const el = document.getElementById(id);
+        if (!el) continue;
+        if (el.getBoundingClientRect().top <= 120) current = id;
+      }
+      setActiveId(current);
+    };
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const scrollTo = (id: string) => {
+    const el = document.getElementById(id);
+    if (!el) return;
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    el.scrollIntoView({ behavior: reduce ? 'instant' : 'smooth', block: 'start' });
+    window.history.replaceState(null, '', `#${id}`);
+    setActiveId(id);
+  };
+
+  return (
+    <InstPageShell>
+      <p className="border-b border-amber-200 bg-amber-50 px-4 py-2 text-center text-[11px] leading-relaxed text-amber-950 sm:text-xs">
+        {P.visibilityNote}
+      </p>
+
+      <nav
+        className="sticky top-0 z-30 border-b border-neutral-200 bg-[#f7f6f3]/90 backdrop-blur"
+        aria-label="Section navigation"
+      >
+        <InstContainer className="flex gap-1.5 overflow-x-auto py-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {P.nav.map((item) => {
+            const active = activeId === item.id;
+            return (
+              <a
+                key={item.id}
+                href={`#${item.id}`}
+                className={cn(
+                  'shrink-0 rounded-full border px-3 py-1.5 text-xs font-medium transition',
+                  active
+                    ? 'border-neutral-950 bg-neutral-950 text-white'
+                    : 'border-neutral-300 bg-white text-neutral-700 hover:border-neutral-500',
+                )}
+                onClick={(e) => {
+                  e.preventDefault();
+                  scrollTo(item.id);
+                }}
+              >
+                {item.label}
+              </a>
+            );
+          })}
+        </InstContainer>
+      </nav>
+
+      <header id="overview" className="scroll-mt-24 border-b border-neutral-200">
+        <InstContainer className="py-12 sm:py-16 md:py-20">
+          <InstSectionLabel>{P.hero.eyebrow}</InstSectionLabel>
+          <h1 className="max-w-4xl font-['MoMA_Sans'] text-3xl font-semibold leading-[1.12] tracking-tight sm:text-4xl md:text-5xl">
+            {P.hero.headline}
+          </h1>
+          <p className="mt-3 text-sm font-medium text-neutral-600 sm:text-base">{P.hero.subheadline}</p>
+          {P.hero.intro.map((para) => (
+            <p key={para.slice(0, 40)} className="mt-4 max-w-3xl text-base leading-relaxed text-neutral-700">
+              {para}
+            </p>
+          ))}
+          <p className="mt-4 max-w-3xl text-sm leading-relaxed text-neutral-600">
+            {P.hero.availability}
+          </p>
+        </InstContainer>
+      </header>
+
+      <section id="fit" className="scroll-mt-24 border-b border-neutral-200 py-12 sm:py-16" aria-labelledby="fit-heading">
+        <InstContainer>
+          <InstSectionLabel>Role alignment</InstSectionLabel>
+          <h2 id="fit-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+            {P.fit.title}
+          </h2>
+          <p className="mt-3 max-w-3xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+            {P.fit.intro}
+          </p>
+          <ul className="mt-8 divide-y divide-neutral-200 border border-neutral-200 bg-white">
+            {P.fit.rows.map((row) => (
+              <li key={row.requirement} className="grid gap-3 p-4 sm:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] sm:gap-6 sm:p-5">
+                <div>
+                  <p className="font-medium text-neutral-950">{row.requirement}</p>
+                  <span
+                    className={cn(
+                      'mt-2 inline-flex rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide',
+                      statusStyles[row.status],
+                    )}
+                  >
+                    {statusLabels[row.status]}
+                  </span>
+                </div>
+                <p className="text-sm leading-relaxed text-neutral-700">{row.evidence}</p>
+              </li>
+            ))}
+          </ul>
+        </InstContainer>
+      </section>
+
+      <section
+        id="programs"
+        className="scroll-mt-24 border-b border-neutral-200 py-12 sm:py-16"
+        aria-labelledby="programs-heading"
+      >
+        <InstContainer>
+          <InstSectionLabel>Programs</InstSectionLabel>
+          <h2 id="programs-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+            {P.programs.title}
+          </h2>
+          <p className="mt-3 max-w-3xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+            {P.programs.intro}
+          </p>
+          <ul className="mt-8 grid gap-4 sm:grid-cols-2">
+            {P.programs.points.map((point, index) => (
+              <li key={point.title} className="border border-neutral-200 bg-white p-5">
+                <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-neutral-500">
+                  {String(index + 1).padStart(2, '0')}
+                </p>
+                <h3 className="mt-2 font-['MoMA_Sans'] text-lg font-semibold">{point.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-neutral-700">{point.body}</p>
+              </li>
+            ))}
+          </ul>
+        </InstContainer>
+      </section>
+
+      <section
+        id="systems"
+        className="scroll-mt-24 border-b border-neutral-200 py-12 sm:py-16"
+        aria-labelledby="systems-heading"
+      >
+        <InstContainer>
+          <InstSectionLabel>Operations</InstSectionLabel>
+          <h2 id="systems-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+            {P.systems.title}
+          </h2>
+          <p className="mt-3 max-w-3xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+            {P.systems.intro}
+          </p>
+          <ul className="mt-6 space-y-2">
+            {P.systems.items.map((item) => (
+              <li
+                key={item}
+                className="border-l-2 border-neutral-950 bg-white/70 py-2.5 pl-3 text-sm leading-relaxed text-neutral-800"
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+          <p className="mt-6 max-w-3xl border border-neutral-200 bg-white p-4 text-sm leading-relaxed text-neutral-600">
+            {P.systems.aiNote}
+          </p>
+        </InstContainer>
+      </section>
+
+      <section
+        id="evidence"
+        className="scroll-mt-24 border-b border-neutral-200 py-12 sm:py-16"
+        aria-labelledby="evidence-heading"
+      >
+        <InstContainer>
+          <InstSectionLabel>Evidence</InstSectionLabel>
+          <h2 id="evidence-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+            {P.evidence.title}
+          </h2>
+          <ul className="mt-8 grid gap-5 md:grid-cols-3">
+            {P.evidence.cards.map((card) => (
+              <li key={card.href}>
+                <Link
+                  href={card.href}
+                  className="group block h-full border border-neutral-200 bg-white transition hover:border-neutral-400"
+                >
+                  <div className="relative aspect-[16/10] bg-neutral-200">
+                    <Image
+                      src={card.imageSrc}
+                      alt={card.imageAlt}
+                      fill
+                      className="object-cover"
+                      sizes="(max-width: 768px) 100vw, 33vw"
+                    />
+                  </div>
+                  <div className="p-4">
+                    <h3 className="font-['MoMA_Sans'] text-base font-semibold">{card.title}</h3>
+                    <p className="mt-2 text-sm leading-relaxed text-neutral-700">{card.body}</p>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </InstContainer>
+      </section>
+
+      <section id="contact" className="scroll-mt-24 py-12 sm:py-16" aria-labelledby="contact-heading">
+        <InstContainer>
+          <InstSectionLabel>Contact</InstSectionLabel>
+          <h2 id="contact-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+            {P.contact.title}
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+            {P.contact.body}
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            <a
+              href={`mailto:${P.contact.email}?subject=${encodeURIComponent(P.contact.emailSubject)}`}
+              className="inline-flex min-h-11 items-center justify-center gap-2 bg-neutral-950 px-5 py-2.5 text-sm font-semibold text-white"
+              onClick={() => track('opportunity_cta_click', { opportunitySlug: 'artist-sustainability', kind: 'email' })}
+            >
+              <Mail className="h-4 w-4" aria-hidden />
+              Email Moises
+            </a>
+            <a
+              href={P.contact.calendly}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex min-h-11 items-center justify-center gap-2 border border-neutral-300 bg-white px-5 py-2.5 text-sm font-medium"
+              onClick={() => track('opportunity_cta_click', { opportunitySlug: 'artist-sustainability', kind: 'calendly' })}
+            >
+              <Calendar className="h-4 w-4" aria-hidden />
+              Calendly
+            </a>
+          </div>
+          <p className="mt-4 text-sm text-neutral-600">{P.contact.site}</p>
+          <ul className="mt-6 flex flex-wrap gap-x-6 gap-y-2 text-sm">
+            {P.contact.related.map((item) => (
+              <li key={item.href}>
+                <Link href={item.href} className="font-medium underline-offset-4 hover:underline">
+                  {item.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </InstContainer>
+      </section>
+    </InstPageShell>
+  );
+}

--- a/src/components/institutions/BakehousePageClient.tsx
+++ b/src/components/institutions/BakehousePageClient.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { bakehousePage } from '@/content/institutions/bakehouse';
+import { track } from '@/lib/analytics';
+import {
+  InstContainer,
+  InstPageShell,
+  InstPlaceholder,
+  InstPrimaryCta,
+  InstSecondaryCta,
+  InstSectionLabel,
+} from '@/components/institutions/InstitutionalUi';
+
+const B = bakehousePage;
+
+const statusStyles: Record<string, string> = {
+  Shipped: 'border-emerald-700/40 bg-emerald-50 text-emerald-950',
+  Proposed: 'border-sky-700/40 bg-sky-50 text-sky-950',
+  'Future opportunity': 'border-neutral-400 bg-neutral-100 text-neutral-800',
+};
+
+export function BakehousePageClient() {
+  return (
+    <InstPageShell>
+      <header className="border-b border-neutral-200">
+        <InstContainer className="grid gap-10 py-12 sm:py-16 lg:grid-cols-12 lg:gap-12 lg:py-20">
+          <div className="lg:col-span-6">
+            <InstSectionLabel>{B.hero.eyebrow}</InstSectionLabel>
+            <h1 className="font-['MoMA_Sans'] text-3xl font-semibold leading-[1.12] tracking-tight sm:text-4xl md:text-5xl">
+              {B.hero.headline}
+            </h1>
+            <p className="mt-5 max-w-xl text-base leading-relaxed text-neutral-700 sm:text-lg">
+              {B.hero.lead}
+            </p>
+            <p className="mt-4 max-w-xl text-sm leading-relaxed text-neutral-600">
+              {B.hero.availability}
+            </p>
+          </div>
+          <div className="lg:col-span-6">
+            <div className="relative aspect-[4/3] overflow-hidden bg-neutral-200">
+              <Image
+                src={B.hero.image.src}
+                alt={B.hero.image.alt}
+                fill
+                className="object-cover"
+                sizes="(max-width: 1024px) 100vw, 50vw"
+                priority
+              />
+            </div>
+            <p className="mt-2 font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+              {B.hero.image.label} · {B.hero.image.note}
+            </p>
+          </div>
+        </InstContainer>
+      </header>
+
+      <div className="space-y-0">
+        {B.buckets.map((bucket) => (
+          <section
+            key={bucket.id}
+            id={bucket.id}
+            className="scroll-mt-24 border-b border-neutral-200 py-12 sm:py-16"
+            aria-labelledby={`${bucket.id}-heading`}
+          >
+            <InstContainer>
+              <span
+                className={`inline-flex rounded-full border px-2.5 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-[0.14em] ${statusStyles[bucket.status] ?? statusStyles['Future opportunity']}`}
+              >
+                {bucket.status}
+              </span>
+              <h2
+                id={`${bucket.id}-heading`}
+                className="mt-4 max-w-3xl font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl"
+              >
+                {bucket.title}
+              </h2>
+              <p className="mt-4 max-w-3xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+                {bucket.body}
+              </p>
+              <ul className="mt-6 grid gap-2 sm:grid-cols-2">
+                {bucket.items.map((item) => (
+                  <li
+                    key={item}
+                    className="border-l-2 border-neutral-950 bg-white/70 py-2.5 pl-3 text-sm leading-relaxed text-neutral-800"
+                  >
+                    {item}
+                  </li>
+                ))}
+              </ul>
+              {bucket.placeholders.length ? (
+                <div className="mt-8 grid gap-3 sm:grid-cols-2">
+                  {bucket.placeholders.map((ph) => (
+                    <InstPlaceholder key={ph.label} label={ph.label} note={ph.note} />
+                  ))}
+                </div>
+              ) : null}
+            </InstContainer>
+          </section>
+        ))}
+      </div>
+
+      <section className="border-b border-neutral-200 py-14 sm:py-16" aria-labelledby="ask-heading">
+        <InstContainer>
+          <InstSectionLabel>Next conversation</InstSectionLabel>
+          <h2 id="ask-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+            {B.ask.title}
+          </h2>
+          <p className="mt-4 max-w-3xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+            {B.ask.body}
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <InstPrimaryCta
+              href={B.ask.primaryCta.href}
+              label={B.ask.primaryCta.label}
+              external={B.ask.primaryCta.external}
+              onClick={() => track('cta_institutions_click', { source: 'bakehouse_ask' })}
+            />
+            <InstSecondaryCta href={B.ask.secondaryCta.href} label={B.ask.secondaryCta.label} />
+          </div>
+        </InstContainer>
+      </section>
+
+      <nav className="py-10" aria-label="Related pages">
+        <InstContainer>
+          <ul className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
+            {B.related.map((item) => (
+              <li key={item.href}>
+                <Link href={item.href} className="font-medium underline-offset-4 hover:underline">
+                  {item.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </InstContainer>
+      </nav>
+    </InstPageShell>
+  );
+}

--- a/src/components/institutions/InstitutionalUi.tsx
+++ b/src/components/institutions/InstitutionalUi.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowUpRight, Calendar } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export function InstSectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.18em] text-neutral-500 sm:text-xs">
+      {children}
+    </p>
+  );
+}
+
+export function InstPlaceholder({
+  label,
+  note,
+}: {
+  label: string;
+  note: string;
+}) {
+  return (
+    <div
+      role="status"
+      className="border border-dashed border-amber-700/45 bg-amber-50 p-3 text-left text-amber-950 sm:p-4"
+    >
+      <p className="mb-1 font-mono text-[10px] uppercase tracking-[0.16em] text-amber-800 sm:text-[11px]">
+        Placeholder
+      </p>
+      <p className="text-sm font-medium">{label}</p>
+      <p className="mt-1 text-xs leading-relaxed text-amber-900/80">{note}</p>
+    </div>
+  );
+}
+
+export function InstPrimaryCta({
+  href,
+  label,
+  external,
+  onClick,
+}: {
+  href: string;
+  label: string;
+  external?: boolean;
+  onClick?: () => void;
+}) {
+  const className =
+    'inline-flex min-h-11 items-center justify-center gap-2 bg-neutral-950 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-neutral-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-950';
+
+  if (external) {
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={className}
+        onClick={onClick}
+      >
+        <Calendar className="h-4 w-4 shrink-0" aria-hidden />
+        {label}
+        <ArrowUpRight className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} className={className} onClick={onClick}>
+      {label}
+    </Link>
+  );
+}
+
+export function InstSecondaryCta({
+  href,
+  label,
+  external,
+}: {
+  href: string;
+  label: string;
+  external?: boolean;
+}) {
+  const className =
+    'inline-flex min-h-11 items-center justify-center border border-neutral-300 bg-white px-5 py-2.5 text-sm font-medium text-neutral-900 transition hover:border-neutral-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-950';
+
+  if (external || href.startsWith('mailto:') || href.startsWith('http')) {
+    return (
+      <a
+        href={href}
+        {...(href.startsWith('http')
+          ? { target: '_blank', rel: 'noopener noreferrer' }
+          : {})}
+        className={className}
+      >
+        {label}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} className={className}>
+      {label}
+    </Link>
+  );
+}
+
+export function InstPageShell({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <main
+      className={cn(
+        'min-h-screen bg-[#f7f6f3] text-neutral-950 antialiased',
+        className,
+      )}
+    >
+      {children}
+    </main>
+  );
+}
+
+export function InstContainer({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn('mx-auto w-full max-w-5xl px-4 sm:px-6 lg:px-8', className)}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/institutions/InstitutionsHubClient.tsx
+++ b/src/components/institutions/InstitutionsHubClient.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { institutionsHub } from '@/content/institutions/hub';
+import { track } from '@/lib/analytics';
+import {
+  InstContainer,
+  InstPageShell,
+  InstPrimaryCta,
+  InstSecondaryCta,
+  InstSectionLabel,
+} from '@/components/institutions/InstitutionalUi';
+
+const H = institutionsHub;
+
+export function InstitutionsHubClient() {
+  return (
+    <InstPageShell>
+      <header className="border-b border-neutral-200 bg-[#f7f6f3]">
+        <InstContainer className="py-14 sm:py-20 md:py-24">
+          <InstSectionLabel>{H.hero.eyebrow}</InstSectionLabel>
+          <h1 className="max-w-4xl font-['MoMA_Sans'] text-3xl font-semibold leading-[1.12] tracking-tight sm:text-4xl md:text-5xl">
+            {H.hero.headline}
+          </h1>
+          <p className="mt-5 max-w-2xl text-base leading-relaxed text-neutral-700 sm:text-lg">
+            {H.hero.lead}
+          </p>
+          <p className="mt-4 max-w-2xl text-sm leading-relaxed text-neutral-600">
+            {H.hero.availability}
+          </p>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            <InstPrimaryCta
+              href={H.hero.primaryCta.href}
+              label={H.hero.primaryCta.label}
+              external={H.hero.primaryCta.external}
+              onClick={() =>
+                track('cta_institutions_click', { source: 'institutions_hero' })
+              }
+            />
+            <InstSecondaryCta href={H.hero.secondaryCta.href} label={H.hero.secondaryCta.label} />
+          </div>
+        </InstContainer>
+      </header>
+
+      <section className="border-b border-neutral-200 py-14 sm:py-16" aria-labelledby="lanes-heading">
+        <InstContainer>
+          <InstSectionLabel>What I build with institutions</InstSectionLabel>
+          <h2 id="lanes-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+            Four lanes of institutional practice
+          </h2>
+          <ul className="mt-10 grid gap-4 sm:grid-cols-2">
+            {H.lanes.map((lane, index) => (
+              <li
+                key={lane.id}
+                className="border border-neutral-200 bg-white p-5 transition hover:border-neutral-400 sm:p-6"
+              >
+                <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-neutral-500">
+                  {String(index + 1).padStart(2, '0')}
+                </p>
+                <h3 className="mt-3 font-['MoMA_Sans'] text-lg font-semibold leading-snug">
+                  {lane.title}
+                </h3>
+                <p className="mt-3 text-sm leading-relaxed text-neutral-700">{lane.body}</p>
+                <Link
+                  href={lane.href}
+                  className="mt-5 inline-flex min-h-10 items-center gap-1.5 text-sm font-semibold text-neutral-950 underline-offset-4 hover:underline"
+                >
+                  {lane.linkLabel}
+                  <ArrowRight className="h-3.5 w-3.5" aria-hidden />
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </InstContainer>
+      </section>
+
+      <section className="border-b border-neutral-200 py-14 sm:py-16" aria-labelledby="proof-heading">
+        <InstContainer>
+          <InstSectionLabel>Evidence</InstSectionLabel>
+          <h2 id="proof-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+            {H.proof.title}
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+            {H.proof.intro}
+          </p>
+          <ul className="mt-10 grid gap-6 md:grid-cols-2">
+            {H.proof.cards.map((card) => (
+              <li key={card.id}>
+                <Link
+                  href={card.href}
+                  className="group block border border-neutral-200 bg-white transition hover:border-neutral-400 hover:shadow-sm"
+                >
+                  <div className="relative aspect-[16/10] overflow-hidden bg-neutral-200">
+                    <Image
+                      src={card.image.src}
+                      alt={card.image.alt}
+                      fill
+                      className="object-cover transition duration-500 group-hover:scale-[1.02] motion-reduce:transition-none motion-reduce:group-hover:scale-100"
+                      sizes="(max-width: 768px) 100vw, 50vw"
+                    />
+                  </div>
+                  <div className="p-5 sm:p-6">
+                    <h3 className="font-['MoMA_Sans'] text-lg font-semibold">{card.title}</h3>
+                    <p className="mt-2 text-sm leading-relaxed text-neutral-700">{card.body}</p>
+                    <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold">
+                      Open page
+                      <ArrowRight className="h-3.5 w-3.5 transition group-hover:translate-x-0.5" aria-hidden />
+                    </span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </InstContainer>
+      </section>
+
+      <section className="py-14 sm:py-16" aria-labelledby="next-heading">
+        <InstContainer>
+          <InstSectionLabel>Engagements</InstSectionLabel>
+          <h2 id="next-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+            {H.nextSteps.title}
+          </h2>
+          <ul className="mt-8 space-y-3">
+            {H.nextSteps.items.map((item) => (
+              <li
+                key={item}
+                className="border-l-2 border-neutral-950 bg-white/60 py-3 pl-4 text-sm leading-relaxed text-neutral-800 sm:text-base"
+              >
+                {item}
+              </li>
+            ))}
+          </ul>
+          <div className="mt-10">
+            <InstPrimaryCta
+              href={H.hero.primaryCta.href}
+              label={H.hero.primaryCta.label}
+              external
+              onClick={() =>
+                track('cta_institutions_click', { source: 'institutions_footer' })
+              }
+            />
+          </div>
+        </InstContainer>
+      </section>
+    </InstPageShell>
+  );
+}

--- a/src/components/institutions/InstitutionsHubClient.tsx
+++ b/src/components/institutions/InstitutionsHubClient.tsx
@@ -1,9 +1,15 @@
 'use client';
 
+import { useEffect, useMemo, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { ArrowRight } from 'lucide-react';
-import { institutionsHub } from '@/content/institutions/hub';
+import { ArrowRight, ArrowUpRight, ExternalLink } from 'lucide-react';
+import {
+  institutionsHub,
+  type InstitutionCaseStudy,
+  type InstitutionOrg,
+  type OrgRelationship,
+} from '@/content/institutions/hub';
 import { track } from '@/lib/analytics';
 import {
   InstContainer,
@@ -12,10 +18,180 @@ import {
   InstSecondaryCta,
   InstSectionLabel,
 } from '@/components/institutions/InstitutionalUi';
+import { cn } from '@/lib/utils';
 
 const H = institutionsHub;
 
+const ORG_FILTERS: Array<{ id: 'all' | OrgRelationship; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'lab', label: 'Lab' },
+  { id: 'residency', label: 'Residency' },
+  { id: 'employment', label: 'Employment' },
+  { id: 'platform', label: 'Platform' },
+  { id: 'workshop', label: 'Workshop' },
+  { id: 'exhibition', label: 'Exhibition' },
+  { id: 'festival', label: 'Festival' },
+  { id: 'funder', label: 'Funder' },
+  { id: 'education', label: 'Education' },
+];
+
+function scrollToId(id: string) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  el.scrollIntoView({ behavior: reduce ? 'instant' : 'smooth', block: 'start' });
+  window.history.replaceState(null, '', `#${id}`);
+}
+
+function CaseStudyCard({ study, large }: { study: InstitutionCaseStudy; large?: boolean }) {
+  const inner = (
+    <>
+      <div className={cn('relative overflow-hidden bg-neutral-200', large ? 'aspect-[16/9]' : 'aspect-[16/10]')}>
+        <Image
+          src={study.imageSrc}
+          alt={study.imageAlt}
+          fill
+          className="object-cover transition duration-500 group-hover:scale-[1.02] motion-reduce:transition-none motion-reduce:group-hover:scale-100"
+          sizes={large ? '(max-width: 768px) 100vw, 50vw' : '(max-width: 768px) 100vw, 33vw'}
+        />
+      </div>
+      <div className="flex flex-1 flex-col p-5 sm:p-6">
+        <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-neutral-500">
+          {study.kindLabel} · {study.org}
+        </p>
+        <h3 className="mt-2 font-['MoMA_Sans'] text-lg font-semibold leading-snug sm:text-xl">
+          {study.title}
+        </h3>
+        <p className="mt-2 flex-1 text-sm leading-relaxed text-neutral-700">{study.body}</p>
+        <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold">
+          {study.external ? 'Open external' : 'Open case study'}
+          {study.external ? (
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+          ) : (
+            <ArrowRight className="h-3.5 w-3.5 transition group-hover:translate-x-0.5" aria-hidden />
+          )}
+        </span>
+      </div>
+    </>
+  );
+
+  const className =
+    'group flex h-full flex-col border border-neutral-200 bg-white transition hover:border-neutral-400 hover:shadow-sm';
+
+  if (study.external) {
+    return (
+      <a href={study.href} target="_blank" rel="noopener noreferrer" className={className}>
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={study.href} className={className}>
+      {inner}
+    </Link>
+  );
+}
+
+function OrgCard({ org }: { org: InstitutionOrg }) {
+  const body = (
+    <>
+      {org.imageSrc ? (
+        <div className="relative aspect-[16/10] overflow-hidden bg-neutral-200">
+          <Image
+            src={org.imageSrc}
+            alt={org.imageAlt ?? org.name}
+            fill
+            className="object-cover"
+            sizes="(max-width: 640px) 100vw, 33vw"
+          />
+        </div>
+      ) : (
+        <div className="flex aspect-[16/10] items-center justify-center bg-neutral-100 px-4 text-center">
+          <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-neutral-500">
+            {org.relationshipLabel}
+          </p>
+        </div>
+      )}
+      <div className="flex flex-1 flex-col p-4 sm:p-5">
+        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+          {org.relationshipLabel}
+        </p>
+        <h3 className="mt-1.5 font-['MoMA_Sans'] text-base font-semibold leading-snug sm:text-lg">
+          {org.name}
+        </h3>
+        <p className="mt-1 text-xs text-neutral-500">{org.location}</p>
+        <p className="mt-2 flex-1 text-sm leading-relaxed text-neutral-700">{org.summary}</p>
+        {org.href ? (
+          <span className="mt-3 inline-flex items-center gap-1 text-sm font-semibold">
+            View
+            {org.external ? (
+              <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
+            ) : (
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden />
+            )}
+          </span>
+        ) : null}
+      </div>
+    </>
+  );
+
+  const className =
+    'group flex h-full flex-col overflow-hidden border border-neutral-200 bg-white transition hover:border-neutral-400';
+
+  if (!org.href) {
+    return <div className={className}>{body}</div>;
+  }
+
+  if (org.external) {
+    return (
+      <a href={org.href} target="_blank" rel="noopener noreferrer" className={className}>
+        {body}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={org.href} className={className}>
+      {body}
+    </Link>
+  );
+}
+
 export function InstitutionsHubClient() {
+  const [activeNav, setActiveNav] = useState('practice');
+  const [orgFilter, setOrgFilter] = useState<'all' | OrgRelationship>('all');
+
+  const featured = useMemo(
+    () => H.caseStudies.filter((c) => c.featured),
+    [],
+  );
+  const moreStudies = useMemo(
+    () => H.caseStudies.filter((c) => !c.featured),
+    [],
+  );
+
+  const filteredOrgs = useMemo(() => {
+    if (orgFilter === 'all') return H.organizations;
+    return H.organizations.filter((o) => o.relationship === orgFilter);
+  }, [orgFilter]);
+
+  useEffect(() => {
+    const ids = H.nav.map((n) => n.id);
+    const onScroll = () => {
+      let current = ids[0];
+      for (const id of ids) {
+        const el = document.getElementById(id);
+        if (!el) continue;
+        if (el.getBoundingClientRect().top <= 110) current = id;
+      }
+      setActiveNav(current);
+    };
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
   return (
     <InstPageShell>
       <header className="border-b border-neutral-200 bg-[#f7f6f3]">
@@ -41,10 +217,64 @@ export function InstitutionsHubClient() {
             />
             <InstSecondaryCta href={H.hero.secondaryCta.href} label={H.hero.secondaryCta.label} />
           </div>
+          <dl className="mt-10 grid max-w-xl grid-cols-3 gap-4 border-t border-neutral-200 pt-8">
+            <div>
+              <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+                Organizations
+              </dt>
+              <dd className="mt-1 font-['MoMA_Sans'] text-2xl font-semibold">{H.organizations.length}</dd>
+            </div>
+            <div>
+              <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+                Case studies
+              </dt>
+              <dd className="mt-1 font-['MoMA_Sans'] text-2xl font-semibold">{H.caseStudies.length}</dd>
+            </div>
+            <div>
+              <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+                Practice lanes
+              </dt>
+              <dd className="mt-1 font-['MoMA_Sans'] text-2xl font-semibold">{H.lanes.length}</dd>
+            </div>
+          </dl>
         </InstContainer>
       </header>
 
-      <section className="border-b border-neutral-200 py-14 sm:py-16" aria-labelledby="lanes-heading">
+      <nav
+        className="sticky top-0 z-30 border-b border-neutral-200 bg-[#f7f6f3]/90 backdrop-blur"
+        aria-label="Page sections"
+      >
+        <InstContainer className="flex gap-1.5 overflow-x-auto py-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {H.nav.map((item) => {
+            const active = activeNav === item.id;
+            return (
+              <a
+                key={item.id}
+                href={`#${item.id}`}
+                className={cn(
+                  'shrink-0 rounded-full border px-3 py-1.5 text-xs font-medium transition',
+                  active
+                    ? 'border-neutral-950 bg-neutral-950 text-white'
+                    : 'border-neutral-300 bg-white text-neutral-700 hover:border-neutral-500',
+                )}
+                onClick={(e) => {
+                  e.preventDefault();
+                  scrollToId(item.id);
+                  setActiveNav(item.id);
+                }}
+              >
+                {item.label}
+              </a>
+            );
+          })}
+        </InstContainer>
+      </nav>
+
+      <section
+        id="practice"
+        className="scroll-mt-24 border-b border-neutral-200 py-14 sm:py-16"
+        aria-labelledby="lanes-heading"
+      >
         <InstContainer>
           <InstSectionLabel>What I build with institutions</InstSectionLabel>
           <h2 id="lanes-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
@@ -76,47 +306,95 @@ export function InstitutionsHubClient() {
         </InstContainer>
       </section>
 
-      <section className="border-b border-neutral-200 py-14 sm:py-16" aria-labelledby="proof-heading">
+      <section
+        id="case-studies"
+        className="scroll-mt-24 border-b border-neutral-200 py-14 sm:py-16"
+        aria-labelledby="case-studies-heading"
+      >
         <InstContainer>
           <InstSectionLabel>Evidence</InstSectionLabel>
-          <h2 id="proof-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
-            {H.proof.title}
+          <h2 id="case-studies-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+            Case studies
           </h2>
           <p className="mt-3 max-w-2xl text-sm leading-relaxed text-neutral-700 sm:text-base">
-            {H.proof.intro}
+            Flagship systems and programs first, then exhibition and festival proof. Each card links to a
+            dedicated page or archive on this site.
           </p>
+
           <ul className="mt-10 grid gap-6 md:grid-cols-2">
-            {H.proof.cards.map((card) => (
-              <li key={card.id}>
-                <Link
-                  href={card.href}
-                  className="group block border border-neutral-200 bg-white transition hover:border-neutral-400 hover:shadow-sm"
-                >
-                  <div className="relative aspect-[16/10] overflow-hidden bg-neutral-200">
-                    <Image
-                      src={card.image.src}
-                      alt={card.image.alt}
-                      fill
-                      className="object-cover transition duration-500 group-hover:scale-[1.02] motion-reduce:transition-none motion-reduce:group-hover:scale-100"
-                      sizes="(max-width: 768px) 100vw, 50vw"
-                    />
-                  </div>
-                  <div className="p-5 sm:p-6">
-                    <h3 className="font-['MoMA_Sans'] text-lg font-semibold">{card.title}</h3>
-                    <p className="mt-2 text-sm leading-relaxed text-neutral-700">{card.body}</p>
-                    <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold">
-                      Open page
-                      <ArrowRight className="h-3.5 w-3.5 transition group-hover:translate-x-0.5" aria-hidden />
-                    </span>
-                  </div>
-                </Link>
+            {featured.map((study) => (
+              <li key={study.id}>
+                <CaseStudyCard study={study} large />
+              </li>
+            ))}
+          </ul>
+
+          <h3 className="mt-12 font-['MoMA_Sans'] text-xl font-semibold sm:text-2xl">
+            More institutional evidence
+          </h3>
+          <ul className="mt-6 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {moreStudies.map((study) => (
+              <li key={study.id}>
+                <CaseStudyCard study={study} />
               </li>
             ))}
           </ul>
         </InstContainer>
       </section>
 
-      <section className="py-14 sm:py-16" aria-labelledby="next-heading">
+      <section
+        id="organizations"
+        className="scroll-mt-24 border-b border-neutral-200 py-14 sm:py-16"
+        aria-labelledby="orgs-heading"
+      >
+        <InstContainer>
+          <InstSectionLabel>Directory</InstSectionLabel>
+          <h2 id="orgs-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+            Organizations worked with
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+            {H.organizations.length} verified institutions — filter by relationship type.
+          </p>
+
+          <div
+            className="mt-6 flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            role="group"
+            aria-label="Filter organizations"
+          >
+            {ORG_FILTERS.map((filter) => {
+              const active = orgFilter === filter.id;
+              return (
+                <button
+                  key={filter.id}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => setOrgFilter(filter.id)}
+                  className={cn(
+                    'shrink-0 rounded-full border px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.12em] transition',
+                    active
+                      ? 'border-neutral-950 bg-neutral-950 text-white'
+                      : 'border-neutral-300 bg-white text-neutral-700 hover:border-neutral-500',
+                  )}
+                >
+                  {filter.label}
+                </button>
+              );
+            })}
+          </div>
+
+          <ul className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {filteredOrgs.map((org) => (
+              <li key={org.id}>
+                <OrgCard org={org} />
+              </li>
+            ))}
+          </ul>
+
+          <p className="mt-8 max-w-3xl text-xs leading-relaxed text-neutral-500">{H.honestyNote}</p>
+        </InstContainer>
+      </section>
+
+      <section id="engage" className="scroll-mt-24 py-14 sm:py-16" aria-labelledby="next-heading">
         <InstContainer>
           <InstSectionLabel>Engagements</InstSectionLabel>
           <h2 id="next-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
@@ -132,7 +410,7 @@ export function InstitutionsHubClient() {
               </li>
             ))}
           </ul>
-          <div className="mt-10">
+          <div className="mt-10 flex flex-col gap-3 sm:flex-row">
             <InstPrimaryCta
               href={H.hero.primaryCta.href}
               label={H.hero.primaryCta.label}
@@ -141,6 +419,7 @@ export function InstitutionsHubClient() {
                 track('cta_institutions_click', { source: 'institutions_footer' })
               }
             />
+            <InstSecondaryCta href="/oolite-arts" label="Start with Oolite proof" />
           </div>
         </InstContainer>
       </section>

--- a/src/components/page/WorkshopClient.tsx
+++ b/src/components/page/WorkshopClient.tsx
@@ -25,6 +25,7 @@ import type { LucideIcon } from 'lucide-react'
 import { motion } from 'framer-motion'
 import { WORKSHOP_HUB, CALENDLY_URL } from '@/constants/workshop-hub'
 import { WORKSHOP_FEATURES, type WorkshopCardVisual } from '@/constants/workshop-features'
+import { institutionalWorkshopOfferings } from '@/content/institutions/workshopsOfferings'
 import { track } from '@/lib/analytics'
 import { useTheme } from '@/contexts/ThemeContext'
 import { cn } from '@/lib/utils'
@@ -293,6 +294,70 @@ export default function WorkshopClient() {
             )}
           </div>
         </motion.div>
+
+        <motion.section
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6, delay: 0.15 }}
+          className="mb-10 sm:mb-16"
+          aria-labelledby="institutional-offerings-heading"
+        >
+          <div className="mb-6 sm:mb-8 text-center max-w-2xl mx-auto">
+            <p
+              className={cn(
+                'text-[11px] font-semibold uppercase tracking-[0.18em] mb-2',
+                isDark ? 'text-purple-300/90' : 'text-violet-700'
+              )}
+            >
+              {institutionalWorkshopOfferings.intro.eyebrow}
+            </p>
+            <h2
+              id="institutional-offerings-heading"
+              className={cn('text-xl sm:text-2xl font-bold', heading)}
+            >
+              {institutionalWorkshopOfferings.intro.title}
+            </h2>
+            <p className={cn('mt-2 text-sm sm:text-base leading-relaxed', bodyMuted)}>
+              {institutionalWorkshopOfferings.intro.lead}
+            </p>
+            <a
+              href={calendlyUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => track('cta_institutions_click', { source: 'workshops_offerings_calendly' })}
+              className="mt-5 inline-flex min-h-11 items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-blue-600 to-purple-600 px-5 py-2.5 text-sm font-medium text-white"
+            >
+              <Phone className="h-4 w-4" aria-hidden />
+              {institutionalWorkshopOfferings.intro.calendlyLabel}
+              <ArrowUpRight className="h-4 w-4" aria-hidden />
+            </a>
+          </div>
+          <ul className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            {institutionalWorkshopOfferings.offerings.map((offering) => (
+              <li key={offering.id} className={cn(cardBase)}>
+                <h3 className={cn('text-base sm:text-lg font-bold leading-snug', heading)}>
+                  {offering.title}
+                </h3>
+                <p className={cn('mt-3 text-xs sm:text-sm leading-relaxed flex-1', bodyMuted)}>
+                  {offering.body}
+                </p>
+                <p className={cn('mt-3 text-[11px] uppercase tracking-wide', bodyMuted)}>
+                  Fits: {offering.fits}
+                </p>
+                <Link
+                  href={offering.relatedHref}
+                  className={cn(
+                    'mt-4 inline-flex items-center gap-1 text-sm font-semibold',
+                    isDark ? 'text-cyan-300' : 'text-violet-700'
+                  )}
+                >
+                  {offering.relatedLabel}
+                  <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </motion.section>
 
         <motion.section
           initial={{ opacity: 0, y: 20 }}

--- a/src/constants/workshop-hub.ts
+++ b/src/constants/workshop-hub.ts
@@ -18,20 +18,20 @@ export const WORKSHOP_HUB = {
   /** Top-of-page band — specific to practice, not generic “bootcamp” copy */
   INTRO: {
     EYEBROW: "Programs & partnerships",
-    TITLE: "Automation, presence, and critical AI — taught from an art practice",
+    TITLE: "Automation, presence, and creative technology — taught from an art practice",
     LEAD:
-      "Hands-on workshops and custom collaborations for artists, educators, and cultural institutions. Built from Oolite Arts programs and public-room teaching — live, accountable, and institution-shaped — not a passive video funnel.",
+      "Three bookable institutional offerings plus deeper workshop programs. Built from Oolite Arts Digital Lab work and public teaching — live, accountable, and institution-shaped.",
   },
 
   CTA_INSTITUTIONS: {
     TITLE: "Work with me (Institutions)",
     BULLETS: [
-      "Automation audits & workflow design",
-      "Institutional memory systems",
-      "Custom agents for your org",
+      "Embedded digital / creative-technology leadership",
+      "Paid workshop pilots for artist communities",
+      "Platforms, kiosks, and institutional workflows",
     ],
-    BUTTON_LABEL: "Schedule a discovery call",
-    LINK: "/contact",
+    BUTTON_LABEL: "Start an institutional conversation",
+    LINK: "/institutions",
   },
 
   CTA_WORKSHOP: {

--- a/src/content/ai24/studio.ts
+++ b/src/content/ai24/studio.ts
@@ -105,7 +105,7 @@ export const AI24_STUDIO = {
       id: 'oolite-digital-lab',
       title: 'Oolite Arts Digital Lab',
       status: 'DEPLOYED' as ProjectStatus,
-      href: '/projects/oolite-digital-lab',
+      href: '/oolite-arts',
       image: {
         src: OOLITE_DIGITAL_LAB_IMAGE,
         alt: OOLITE_DIGITAL_LAB_IMAGE_ALT,

--- a/src/content/institutions/artistSustainability.ts
+++ b/src/content/institutions/artistSustainability.ts
@@ -1,0 +1,159 @@
+/**
+ * /artist-sustainability — private YoungArts application supplement.
+ * AI is supporting evidence, not the headline.
+ */
+
+import { OOLITE_DIGITAL_LAB_IMAGE, OOLITE_DIGITAL_LAB_IMAGE_ALT } from '@/content/evidence/projects';
+import { INSTITUTIONAL_AVAILABILITY, INSTITUTIONAL_CALENDLY_URL } from './shared';
+
+const CDN = 'https://res.cloudinary.com/dck5rzi4h/image/upload';
+const BAKEHOUSE_IMAGE = `${CDN}/v1717960571/art/moisestech-website/digitaldivinities-moisesdsanabria-fabiolalarios-bakehouse-openstudios-spring-2024_f3ahbx.jpg`;
+
+export const artistSustainabilityPage = {
+  meta: {
+    title: 'Artist Sustainability — YoungArts Application Supplement | Moises Sanabria',
+    description:
+      'Private portfolio page for YoungArts Senior Manager, Artist Sustainability: artist-centered programs, operations, data systems, mentorship infrastructure, and institutional partnerships.',
+    url: 'https://moises.tech/artist-sustainability',
+    indexable: false,
+  },
+  visibilityNote:
+    'Private application supplement — unlisted, noindex. Prepared for YoungArts Lifetime Support for Artists.',
+  hero: {
+    eyebrow: 'YoungArts · Application supplement',
+    headline: 'Artist-centered systems that sustain practice across a career.',
+    subheadline:
+      'Senior Manager, Artist Sustainability · Lifetime Support for Artists — Moises Sanabria',
+    intro: [
+      'I build programs and operational systems that help artists move through career stages with clarity: mentorship infrastructure, documentation, partnerships, data hygiene, and the quiet logistics that keep support real.',
+      'This page supplements my August 3 application. It foregrounds institutional practice at Oolite Arts and Bakehouse Art Complex—not an AI product pitch.',
+    ],
+    availability: INSTITUTIONAL_AVAILABILITY,
+  },
+  nav: [
+    { id: 'overview', label: 'Overview' },
+    { id: 'fit', label: 'Role alignment' },
+    { id: 'programs', label: 'Programs & ops' },
+    { id: 'systems', label: 'Data & systems' },
+    { id: 'evidence', label: 'Evidence' },
+    { id: 'contact', label: 'Contact' },
+  ],
+  fit: {
+    title: 'Alignment with Artist Sustainability',
+    intro:
+      'Mapped to Lifetime Support responsibilities: program architecture, artist services, relationships, reporting, and cross-disciplinary support. YoungArts employment is not claimed.',
+    rows: [
+      {
+        requirement: 'Artist-centered program architecture',
+        evidence:
+          'Oolite Digital Lab: workshops, open hours, documentation, and sustained artist support designed as one connected program—not isolated classes.',
+        status: 'demonstrated' as const,
+      },
+      {
+        requirement: 'Career-stage resources and mentorship infrastructure',
+        evidence:
+          'Public workshops, one-on-one artist support, and literacy programs that translate emerging tools into finishable practice without flattening authorship.',
+        status: 'demonstrated' as const,
+      },
+      {
+        requirement: 'Data systems, documentation, and reporting',
+        evidence:
+          'Institutional documentation, handoff materials, and operational records across lab and screen systems. Airtable/CRM depth labeled honestly where role-specific tooling differs.',
+        status: 'transferable' as const,
+      },
+      {
+        requirement: 'Contracts, budgets, communications, partnerships',
+        evidence:
+          'Vendor and equipment coordination; cross-institutional collaboration; clear communication with artists and staff. Formal nonprofit ACD/HR title path not claimed.',
+        status: 'transferable' as const,
+      },
+      {
+        requirement: 'Wellness / capacity as sustainable practice',
+        evidence:
+          'Workshop pedagogy that treats attention, burnout culture, and human review as part of sustainable creative work—not only productivity tooling.',
+        status: 'transferable' as const,
+      },
+      {
+        requirement: 'YoungArts Lifetime Support employment history',
+        evidence: 'Not claimed. This page is an application supplement for the Senior Manager role.',
+        status: 'todo' as const,
+      },
+    ],
+  },
+  programs: {
+    title: 'Programs across career stages',
+    intro:
+      'Support that holds when artists change mediums, tools, and institutions—operations as care, not bureaucracy for its own sake.',
+    points: [
+      {
+        title: 'Entry and orientation',
+        body: 'Onboarding into shared facilities, tools, and expectations so artists can start making without guesswork.',
+      },
+      {
+        title: 'Skill and practice development',
+        body: 'Workshops and coaching that build durable studio habits: documentation, presence, automation under human control, fabrication literacy.',
+      },
+      {
+        title: 'Visibility and partnerships',
+        body: 'Screens, portals, and communications that connect studio activity to audiences and institutional partners without overclaiming outcomes.',
+      },
+      {
+        title: 'Capacity and continuity',
+        body: 'Handoff docs, templates, and review checkpoints so support survives staff turnover and artist transitions.',
+      },
+    ],
+  },
+  systems: {
+    title: 'Operational systems (supporting evidence)',
+    intro:
+      'Technology here is infrastructure for artist support—Airtable-style records, documentation, contractor coordination, and reporting—not the brand story.',
+    items: [
+      'Documentation and handoff packages for labs and display systems',
+      'Content and device workflows (SmartSigns / Anthias operations)',
+      'Proposed artist portal governance on Assembly (Bakehouse)',
+      'Workshop curricula and reusable educational resources',
+      'AI literacy and studio automation taught with human review gates',
+    ],
+    aiNote:
+      'AI appears only as one method inside artist-centered operations and teaching—not as the headline of this application.',
+  },
+  evidence: {
+    title: 'Selected evidence',
+    cards: [
+      {
+        title: 'Oolite Arts Digital Lab',
+        body: 'Technical direction: lab operations, workshops, equipment systems, artist support, documentation.',
+        href: '/oolite-arts',
+        imageSrc: OOLITE_DIGITAL_LAB_IMAGE,
+        imageAlt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
+      },
+      {
+        title: 'Bakehouse digital systems',
+        body: 'Shipped SmartSigns / kiosk infrastructure; Artist Portal proposed on Assembly; connected communications next.',
+        href: '/bakehouse',
+        imageSrc: BAKEHOUSE_IMAGE,
+        imageAlt: 'Bakehouse Art Complex — public-facing cultural context',
+      },
+      {
+        title: 'Workshops for artists and institutions',
+        body: 'Bookable programs in digital presence, studio automation, and creative-technology prototyping.',
+        href: '/workshops',
+        imageSrc: OOLITE_DIGITAL_LAB_IMAGE,
+        imageAlt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
+      },
+    ],
+  },
+  contact: {
+    title: 'Contact',
+    body: 'Thank you for considering this supplement alongside my August 3 application.',
+    email: 'm@moises.tech',
+    emailSubject: 'YoungArts — Artist Sustainability — Moises Sanabria',
+    site: 'https://moises.tech',
+    calendly: INSTITUTIONAL_CALENDLY_URL,
+    related: [
+      { label: 'Institutions hub', href: '/institutions' },
+      { label: 'Oolite Arts', href: '/oolite-arts' },
+      { label: 'Bakehouse', href: '/bakehouse' },
+    ],
+  },
+} as const;

--- a/src/content/institutions/bakehouse.ts
+++ b/src/content/institutions/bakehouse.ts
@@ -1,0 +1,113 @@
+/**
+ * /bakehouse — institutional digital systems page for Bakehouse Art Complex.
+ * Clearly separate shipped work, proposed work, and future opportunity.
+ */
+
+import {
+  INSTITUTIONAL_AVAILABILITY,
+  INSTITUTIONAL_CALENDLY_URL,
+  type PlaceholderAsset,
+} from './shared';
+
+const CDN = 'https://res.cloudinary.com/dck5rzi4h/image/upload';
+const BAKEHOUSE_IMAGE = `${CDN}/v1717960571/art/moisestech-website/digitaldivinities-moisesdsanabria-fabiolalarios-bakehouse-openstudios-spring-2024_f3ahbx.jpg`;
+
+export const bakehousePage = {
+  meta: {
+    title: 'Bakehouse Art Complex — Digital Systems | Moises Sanabria',
+    description:
+      'SmartSigns and kiosk infrastructure shipped at Bakehouse Art Complex; Artist Portal proposed on Assembly; a connected institutional communication system as the next layer.',
+    url: 'https://moises.tech/bakehouse',
+  },
+  hero: {
+    eyebrow: 'Bakehouse Art Complex',
+    headline: 'Digital systems that make an artist building legible.',
+    lead:
+      'Screens, workflows, and artist-facing infrastructure—so studios, events, and public life stay connected without turning artists into systems administrators.',
+    availability: INSTITUTIONAL_AVAILABILITY,
+    image: {
+      src: BAKEHOUSE_IMAGE,
+      alt: 'Bakehouse Art Complex — open studios context',
+      label: 'Context photo',
+      note: 'Production SmartSign installation photos pending; this image is contextual Bakehouse work.',
+    } satisfies PlaceholderAsset & { src: string; alt: string },
+  },
+  buckets: [
+    {
+      id: 'shipped',
+      status: 'Shipped',
+      title: 'SmartSigns, kiosks, and display infrastructure',
+      body: 'Vertical smart-sign systems and Raspberry Pi / Anthias-based display workflows that promote artists, events, and studio activity through a repeatable screen format. Handoff of Anthias/SmartSigns operations is in progress.',
+      items: [
+        'Artist and event promotion on vertical screens',
+        'Raspberry Pi / Anthias display stack',
+        'Repeatable content formats for building life',
+        'Operational coordination with Bakehouse technology leadership',
+      ],
+      placeholders: [
+        {
+          label: 'Live SmartSign installation photo',
+          note: 'Permission-cleared photo of a running Bakehouse screen.',
+        },
+        {
+          label: 'Anthias dashboard / device still',
+          note: 'Operational still showing device management (no credentials).',
+        },
+      ] satisfies PlaceholderAsset[],
+    },
+    {
+      id: 'proposed',
+      status: 'Proposed',
+      title: 'Artist Portal on Assembly',
+      body: 'An artist-facing portal running on Assembly to extend content governance across spatial screens and digital touchpoints—so artists and staff can update institutional visibility without ad-hoc file drops.',
+      items: [
+        'Artist-facing content submission and updates',
+        'Governance for what appears on screens and related channels',
+        'Connection between studio activity and public communication',
+        'Built to reduce one-off requests and lost files',
+      ],
+      placeholders: [
+        {
+          label: 'Assembly portal wireframes / screens',
+          note: 'Mark shipped screens vs proposed flows when ready.',
+        },
+      ] satisfies PlaceholderAsset[],
+    },
+    {
+      id: 'future',
+      status: 'Future opportunity',
+      title: 'A connected institutional communication system',
+      body: 'The next layer is not another isolated tool. It is coherence: SmartSigns, Artist Portal, artist communications, digital programming, and technical infrastructure operating as one system under embedded digital leadership.',
+      items: [
+        'Shared content model across screens, portal, and programming',
+        'Clear roles for staff, artists, and contractors',
+        'Documentation and handoff so the system survives turnover',
+        '6–12 month embedded / fractional digital leadership option',
+      ],
+      placeholders: [
+        {
+          label: 'System map diagram',
+          note: 'One diagram: screens ↔ Assembly portal ↔ programming ↔ ops.',
+        },
+      ] satisfies PlaceholderAsset[],
+    },
+  ],
+  ask: {
+    title: 'Conversation for Bakehouse leadership',
+    body: 'Rather than proposing another isolated project, the useful next step is an embedded part-time role or six-to-twelve-month engagement focused on digital strategy, artist technology, and institutional systems.',
+    primaryCta: {
+      label: 'Schedule 30 minutes',
+      href: INSTITUTIONAL_CALENDLY_URL,
+      external: true,
+    },
+    secondaryCta: {
+      label: 'Related Oolite proof',
+      href: '/oolite-arts',
+    },
+  },
+  related: [
+    { label: 'Institutions hub', href: '/institutions' },
+    { label: 'SmartSign service page', href: '/services/smartsign' },
+    { label: 'Oolite Arts case study', href: '/oolite-arts' },
+  ],
+} as const;

--- a/src/content/institutions/hub.ts
+++ b/src/content/institutions/hub.ts
@@ -1,8 +1,15 @@
 /**
  * /institutions — modular institutional portfolio hub.
+ * Organizations and case studies must match verified site/CV evidence.
+ * Do not invent affiliations. Application-only orgs stay out of the worked-with list.
  */
 
-import { OOLITE_DIGITAL_LAB_IMAGE, OOLITE_DIGITAL_LAB_IMAGE_ALT } from '@/content/evidence/projects';
+import {
+  AI24_WEBSITE_HERO_IMAGE,
+  OOLITE_DIGITAL_LAB_IMAGE,
+  OOLITE_DIGITAL_LAB_IMAGE_ALT,
+  evidenceProjects,
+} from '@/content/evidence/projects';
 import {
   INSTITUTIONAL_AVAILABILITY,
   INSTITUTIONAL_CALENDLY_URL,
@@ -11,19 +18,79 @@ import {
 
 const CDN = 'https://res.cloudinary.com/dck5rzi4h/image/upload';
 const BAKEHOUSE_IMAGE = `${CDN}/v1717960571/art/moisestech-website/digitaldivinities-moisesdsanabria-fabiolalarios-bakehouse-openstudios-spring-2024_f3ahbx.jpg`;
+const BAKEHOUSE_STUDIO = `${CDN}/v1783907488/art/moisestech-website/studio/moises-sanabria-open-studios-red-world-eye-2024_zdyayj.jpg`;
+const LOCUST_IMAGE =
+  'https://res.cloudinary.com/du1ysiumj/image/upload/v1774829074/the-art-of-ai-agents-locust-projects-the-dill-2026_xjb76m.jpg';
+const SMART_SHOPPERS = `${CDN}/v1737831876/art/moisestech-website/smart_shoppers__bsw9ko.jpg`;
+const TOUCH_GRASS = `${CDN}/v1737831895/art/moisestech-website/touchgrass-doomscrolling-treadmill-stations-6_cwf4ns.jpg`;
+const MOMUS = `${CDN}/v1740950484/art/moisestech-website/exhibitions/apr_2025_technofetishism_momus/momus-exhibition-banner_uun9rx.jpg`;
+const ICA_NOTIONS = `${CDN}/v1739483923/art/moisestech-website/exhibitions/dec_2024_dminti_notions_of_home/NotionsOfHome_banner_soubxf.jpg`;
+const TRANSMEDIALE = `${CDN}/v1739483432/art/moisestech-website/exhibitions/oct_2024_post_masters_low_resolution/oct_2024_post_masters_low_resolution_poster_utzgio.png`;
+const AFIRME = `${CDN}/v1751123479/art/moisestech-website/exhibitions/june_2025_algoritmica_intima_cdmx/algoritmica-intima-exhibitions-june-2025_zmg4mq.jpg`;
+const DCC = evidenceProjects['digital-culture-infrastructure'];
+
+export type OrgRelationship =
+  | 'lab'
+  | 'residency'
+  | 'employment'
+  | 'exhibition'
+  | 'workshop'
+  | 'platform'
+  | 'funder'
+  | 'education'
+  | 'festival';
+
+export type InstitutionOrg = {
+  id: string;
+  name: string;
+  location: string;
+  relationship: OrgRelationship;
+  relationshipLabel: string;
+  summary: string;
+  href?: string;
+  external?: boolean;
+  imageSrc?: string;
+  imageAlt?: string;
+};
+
+export type InstitutionCaseStudy = {
+  id: string;
+  title: string;
+  org: string;
+  kind: 'systems' | 'program' | 'exhibition' | 'platform' | 'workshop';
+  kindLabel: string;
+  body: string;
+  href: string;
+  external?: boolean;
+  imageSrc: string;
+  imageAlt: string;
+  featured?: boolean;
+};
+
+export const ORG_RELATIONSHIP_LABELS: Record<OrgRelationship, string> = {
+  lab: 'Lab operations',
+  residency: 'Studio residency',
+  employment: 'Employment',
+  exhibition: 'Exhibition',
+  workshop: 'Workshop / teaching',
+  platform: 'Platform build',
+  funder: 'Funder',
+  education: 'Education partner',
+  festival: 'Festival host',
+};
 
 export const institutionsHub = {
   meta: {
     title: 'Institutions — Artist-Centered Digital Systems | Moises Sanabria',
     description:
-      'Embedded digital leadership, artist professional-development programs, institutional platforms and workflows, and creative-technology prototypes for cultural organizations.',
+      'Organizations and case studies from Moises Sanabria’s institutional practice: Oolite Arts Digital Lab, Bakehouse Art Complex, Locust Projects, ICA Miami, DCC Miami, and exhibition partners.',
     url: 'https://moises.tech/institutions',
   },
   hero: {
     eyebrow: 'Institutional practice',
     headline: 'I build artist-centered digital systems, programs, and experiences.',
     lead:
-      'Not a generic availability pitch. A practice connecting programming, technology, infrastructure, and institutional operations—so artists can make work without becoming IT staff.',
+      'A practice connecting programming, technology, infrastructure, and institutional operations—so artists can make work without becoming IT staff. Below: verified organizations and case studies from that work.',
     availability: INSTITUTIONAL_AVAILABILITY,
     primaryCta: {
       label: 'Start an institutional conversation',
@@ -35,6 +102,12 @@ export const institutionsHub = {
       href: 'mailto:m@moises.tech?subject=Institutional%20conversation%20%E2%80%94%20Moises%20Sanabria',
     },
   },
+  nav: [
+    { id: 'practice', label: 'Practice' },
+    { id: 'case-studies', label: 'Case studies' },
+    { id: 'organizations', label: 'Organizations' },
+    { id: 'engage', label: 'Engage' },
+  ],
   lanes: [
     {
       id: 'embedded-leadership',
@@ -47,8 +120,8 @@ export const institutionsHub = {
       id: 'artist-pd',
       title: 'Artist professional-development programs',
       body: 'Workshops, mentorship infrastructure, and career-stage resources designed for artists—operations, capacity, and craft together.',
-      href: '/artist-sustainability',
-      linkLabel: 'Artist sustainability portfolio',
+      href: '/workshops',
+      linkLabel: 'Bookable workshops',
     },
     {
       id: 'platforms',
@@ -61,40 +134,359 @@ export const institutionsHub = {
       id: 'prototypes',
       title: 'Creative-technology prototypes and public experiences',
       body: 'Fabrication workflows, public installations, and educational toolkits that move from lab experiment to shared institutional capacity.',
-      href: '/workshops',
-      linkLabel: 'Bookable workshops',
+      href: '/ai24',
+      linkLabel: 'AI24 studio',
     },
   ] satisfies InstitutionalLane[],
-  proof: {
-    title: 'Flagship proof',
-    intro: 'Start with the work already built inside Miami institutions.',
-    cards: [
-      {
-        id: 'oolite',
-        title: 'Oolite Arts Digital Lab',
-        body: 'Lab build and operations, workshops, equipment systems, documentation, and handoff.',
-        href: '/oolite-arts',
-        image: {
-          src: OOLITE_DIGITAL_LAB_IMAGE,
-          alt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
-          label: 'Lab context',
-          note: 'Production finished-lab photography pending.',
-        },
-      },
-      {
-        id: 'bakehouse',
-        title: 'Bakehouse Art Complex',
-        body: 'Shipped SmartSigns and kiosk infrastructure; Artist Portal proposed on Assembly; connected communications system next.',
-        href: '/bakehouse',
-        image: {
-          src: BAKEHOUSE_IMAGE,
-          alt: 'Bakehouse Art Complex — open studios and public-facing cultural context',
-          label: 'Building context',
-          note: 'Live SmartSign installation photo pending.',
-        },
-      },
-    ],
-  },
+  caseStudies: [
+    {
+      id: 'oolite-digital-lab',
+      title: 'Oolite Arts Digital Lab',
+      org: 'Oolite Arts',
+      kind: 'systems',
+      kindLabel: 'Systems · Lab ops',
+      body: 'Technical direction turning space, tools, curriculum, documentation, and sustained artist support into an accessible creative-technology program.',
+      href: '/oolite-arts',
+      imageSrc: OOLITE_DIGITAL_LAB_IMAGE,
+      imageAlt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
+      featured: true,
+    },
+    {
+      id: 'bakehouse-systems',
+      title: 'Bakehouse digital systems',
+      org: 'Bakehouse Art Complex',
+      kind: 'systems',
+      kindLabel: 'Systems · Screens',
+      body: 'Shipped SmartSigns and Raspberry Pi / Anthias kiosk infrastructure; Artist Portal proposed on Assembly; connected institutional communications next.',
+      href: '/bakehouse',
+      imageSrc: BAKEHOUSE_IMAGE,
+      imageAlt: 'Bakehouse Art Complex — open studios and public-facing cultural context',
+      featured: true,
+    },
+    {
+      id: 'smartsign',
+      title: 'SmartSign institutional display',
+      org: 'Bakehouse · Infra24',
+      kind: 'platform',
+      kindLabel: 'Platform',
+      body: 'Repeatable vertical display formats for artists, events, and studio activity—service and workshop surface for institutional screens.',
+      href: '/services/smartsign',
+      imageSrc: BAKEHOUSE_STUDIO,
+      imageAlt: 'Bakehouse studio context for public-facing screen systems',
+    },
+    {
+      id: 'dcc-miami',
+      title: 'Digital Culture Center Miami',
+      org: 'DCC Miami',
+      kind: 'platform',
+      kindLabel: 'Platform',
+      body: DCC.summary,
+      href: DCC.href ?? 'https://dcc.miami',
+      external: true,
+      imageSrc: DCC.imageSrc,
+      imageAlt: DCC.imageAlt,
+    },
+    {
+      id: 'locust-ai-agents',
+      title: 'The Art of AI Agents',
+      org: 'Locust Projects',
+      kind: 'workshop',
+      kindLabel: 'Workshop',
+      body: 'Public workshop and talk on artist task automation, agents, and human review—delivered in a Miami contemporary art context.',
+      href: '/workshop/the-art-of-ai-agents',
+      imageSrc: LOCUST_IMAGE,
+      imageAlt: 'The Art of AI Agents workshop at Locust Projects',
+      featured: true,
+    },
+    {
+      id: 'ai24-studio',
+      title: 'AI24 — cultural R&D and literacy',
+      org: 'AI24',
+      kind: 'program',
+      kindLabel: 'Program · Platform',
+      body: 'AI literacy, tools, and cultural R&D systems for artists and institutions—education, prototypes, and public-facing programs.',
+      href: '/ai24',
+      imageSrc: AI24_WEBSITE_HERO_IMAGE,
+      imageAlt: 'AI24 website — program and product hub',
+    },
+    {
+      id: 'ica-employment',
+      title: 'ICA Miami — digital production',
+      org: 'Institute of Contemporary Art, Miami',
+      kind: 'program',
+      kindLabel: 'Employment · Exhibition',
+      body: 'Digital Producer (2019–2020) plus later exhibition contexts including Notions of Home (ICA × Dminti).',
+      href: '/cv',
+      imageSrc: ICA_NOTIONS,
+      imageAlt: 'Notions of Home — ICA Miami × Dminti exhibition banner',
+    },
+    {
+      id: 'munag-continuum',
+      title: 'CONTINUUM — Smart Shoppers',
+      org: 'MUNAG · Fundación Paiz',
+      kind: 'exhibition',
+      kindLabel: 'Exhibition',
+      body: 'International museum exhibition of Smart Shoppers / Price of Existence—cognition staged as consumer product within CONTINUUM.',
+      href: '/art/smart-shoppers',
+      imageSrc: SMART_SHOPPERS,
+      imageAlt: 'Smart Shoppers — CONTINUUM exhibition work',
+    },
+    {
+      id: 'museum-of-sex',
+      title: 'Taste the Algorithm',
+      org: 'Museum of Sex Miami',
+      kind: 'exhibition',
+      kindLabel: 'Exhibition',
+      body: 'F*ck Art: Nature & Artifice — Miami exhibition examining ecology, technology, and mediated desire.',
+      href: '/ai24',
+      imageSrc: TRANSMEDIALE,
+      imageAlt: 'Exhibition context for Taste the Algorithm / related screening materials',
+    },
+    {
+      id: 'momus-technofetishism',
+      title: 'Technofetishism',
+      org: 'MOMus — Thessaloniki',
+      kind: 'exhibition',
+      kindLabel: 'Exhibition',
+      body: 'International exhibition at MOMus Experimental Center for the Arts.',
+      href: '/calendar/exhibitions',
+      imageSrc: MOMUS,
+      imageAlt: 'MOMus Technofetishism exhibition banner',
+    },
+    {
+      id: 'chroma-touch-grass',
+      title: 'Touch Grass / Doomscrolling',
+      org: 'Chroma Art Film Festival · Superblue',
+      kind: 'exhibition',
+      kindLabel: 'Festival install',
+      body: 'Public festival installation staging attention, bodies, and platform governance.',
+      href: '/art/doomscrolling_treadmill',
+      imageSrc: TOUCH_GRASS,
+      imageAlt: 'Doomscrolling Treadmill / Touch Grass festival install',
+    },
+    {
+      id: 'algoritmica-intima',
+      title: 'Algoritmica Intima: Runtime',
+      org: 'Centro Cultural Afirme · CDMX',
+      kind: 'exhibition',
+      kindLabel: 'Exhibition',
+      body: 'Exhibition on algorithms, intimacy, and computational experience in Mexico City.',
+      href: '/calendar/exhibitions',
+      imageSrc: AFIRME,
+      imageAlt: 'Algoritmica Intima exhibition, Centro Cultural Afirme',
+    },
+  ] satisfies InstitutionCaseStudy[],
+  organizations: [
+    {
+      id: 'oolite',
+      name: 'Oolite Arts',
+      location: 'Miami Beach, FL',
+      relationship: 'lab',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.lab,
+      summary:
+        'Technical Director of Digital — Knight-supported Digital Lab: workshops, fabrication, documentation, and artist support.',
+      href: '/oolite-arts',
+      imageSrc: OOLITE_DIGITAL_LAB_IMAGE,
+      imageAlt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
+    },
+    {
+      id: 'bakehouse',
+      name: 'Bakehouse Art Complex',
+      location: 'Miami, FL',
+      relationship: 'residency',
+      relationshipLabel: 'Studio residency · Systems',
+      summary:
+        'Studio 43 residency; SmartSigns / Anthias display systems; open studios; proposed Artist Portal on Assembly.',
+      href: '/bakehouse',
+      imageSrc: BAKEHOUSE_STUDIO,
+      imageAlt: 'Bakehouse Art Complex — Studio 43 and open studios context',
+    },
+    {
+      id: 'locust',
+      name: 'Locust Projects',
+      location: 'Miami, FL',
+      relationship: 'workshop',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.workshop,
+      summary: 'Public workshops and talks including The Art of AI Agents / Artist in the Automation.',
+      href: '/workshop/the-art-of-ai-agents',
+      imageSrc: LOCUST_IMAGE,
+      imageAlt: 'Workshop at Locust Projects',
+    },
+    {
+      id: 'ica',
+      name: 'Institute of Contemporary Art, Miami',
+      location: 'Miami, FL',
+      relationship: 'employment',
+      relationshipLabel: 'Employment · Exhibition',
+      summary: 'Digital Producer (2019–2020); later exhibition contexts including Notions of Home.',
+      href: '/cv',
+      imageSrc: ICA_NOTIONS,
+      imageAlt: 'ICA Miami exhibition context',
+    },
+    {
+      id: 'dcc',
+      name: 'Digital Culture Center Miami',
+      location: 'Miami, FL',
+      relationship: 'platform',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.platform,
+      summary: 'Institutional website and digital infrastructure for cultural programming.',
+      href: 'https://dcc.miami',
+      external: true,
+      imageSrc: DCC.imageSrc,
+      imageAlt: DCC.imageAlt,
+    },
+    {
+      id: 'knight',
+      name: 'John S. and James L. Knight Foundation',
+      location: 'Miami / national',
+      relationship: 'funder',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.funder,
+      summary: 'Funder of Oolite Arts Digital Lab; related civic-technology and proposal work archived on site.',
+      href: '/grant/knight-foundation',
+      imageSrc: OOLITE_DIGITAL_LAB_IMAGE,
+      imageAlt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
+    },
+    {
+      id: 'mdc-idea',
+      name: 'MDC Idea Center',
+      location: 'Miami, FL',
+      relationship: 'education',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.education,
+      summary: 'AI Sprint for Artists — workshop and education partnership.',
+      href: '/workshops',
+    },
+    {
+      id: 'museum-of-sex',
+      name: 'Museum of Sex Miami',
+      location: 'Miami, FL',
+      relationship: 'exhibition',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.exhibition,
+      summary: 'F*ck Art: Nature & Artifice — Taste the Algorithm.',
+      href: '/calendar/exhibitions',
+    },
+    {
+      id: 'munag',
+      name: 'MUNAG — National Museum of Art of Guatemala',
+      location: 'Guatemala',
+      relationship: 'exhibition',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.exhibition,
+      summary: 'CONTINUUM — Smart Shoppers and The Price of Existence (with collaborators).',
+      href: '/art/smart-shoppers',
+      imageSrc: SMART_SHOPPERS,
+      imageAlt: 'Smart Shoppers exhibition work',
+    },
+    {
+      id: 'paiz',
+      name: 'Fundación Paiz',
+      location: 'Guatemala',
+      relationship: 'exhibition',
+      relationshipLabel: 'Exhibition partner',
+      summary: 'Support / partner context for CONTINUUM exhibition work.',
+      href: '/art/smart-shoppers',
+      imageSrc: SMART_SHOPPERS,
+      imageAlt: 'CONTINUUM exhibition context',
+    },
+    {
+      id: 'momus',
+      name: 'MOMus',
+      location: 'Thessaloniki, Greece',
+      relationship: 'exhibition',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.exhibition,
+      summary: 'Technofetishism — MOMus Experimental Center for the Arts.',
+      href: '/calendar/exhibitions',
+      imageSrc: MOMUS,
+      imageAlt: 'MOMus exhibition banner',
+    },
+    {
+      id: 'chroma',
+      name: 'Chroma Art Film Festival',
+      location: 'Miami, FL',
+      relationship: 'festival',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.festival,
+      summary: 'Touch Grass / Doomscrolling public festival install.',
+      href: '/art/doomscrolling_treadmill',
+      imageSrc: TOUCH_GRASS,
+      imageAlt: 'Touch Grass festival install',
+    },
+    {
+      id: 'superblue',
+      name: 'Superblue',
+      location: 'Miami, FL',
+      relationship: 'festival',
+      relationshipLabel: 'Festival venue',
+      summary: 'Host context for Chroma / Touch Grass festival presentation.',
+      href: '/art/doomscrolling_treadmill',
+      imageSrc: TOUCH_GRASS,
+      imageAlt: 'Festival install context',
+    },
+    {
+      id: 'transmediale',
+      name: 'transmediale',
+      location: 'Berlin, Germany',
+      relationship: 'exhibition',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.exhibition,
+      summary: 'Dark Drives / Incompatible (2012, ART404) — archival exhibition credit.',
+      href: '/calendar/exhibitions',
+    },
+    {
+      id: 'hkw',
+      name: 'Haus der Kulturen der Welt (HKW)',
+      location: 'Berlin, Germany',
+      relationship: 'exhibition',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.exhibition,
+      summary: 'International presentation context with transmediale.',
+      href: '/calendar/exhibitions',
+    },
+    {
+      id: 'afirme',
+      name: 'Centro Cultural Afirme',
+      location: 'Mexico City, Mexico',
+      relationship: 'exhibition',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.exhibition,
+      summary: 'Algoritmica Intima: Runtime (2025).',
+      href: '/calendar/exhibitions',
+      imageSrc: AFIRME,
+      imageAlt: 'Algoritmica Intima exhibition',
+    },
+    {
+      id: 'postmasters',
+      name: 'Postmasters Gallery',
+      location: 'New York, NY',
+      relationship: 'exhibition',
+      relationshipLabel: 'Screening',
+      summary: 'Low Resolution screening (2024).',
+      href: '/calendar/exhibitions',
+      imageSrc: TRANSMEDIALE,
+      imageAlt: 'Low Resolution screening poster',
+    },
+    {
+      id: 'cooper',
+      name: 'The Cooper Union',
+      location: 'New York, NY',
+      relationship: 'education',
+      relationshipLabel: 'Education',
+      summary: 'BFA; early exhibition context (F* Real Life, 2015).',
+      href: '/bio',
+    },
+    {
+      id: 'sfpc',
+      name: 'School for Poetic Computation',
+      location: 'New York, NY',
+      relationship: 'education',
+      relationshipLabel: 'Education',
+      summary: '2013 cohort — computational art and poetic systems.',
+      href: '/bio',
+    },
+    {
+      id: 'nwsa',
+      name: 'New World School of the Arts',
+      location: 'Miami, FL',
+      relationship: 'education',
+      relationshipLabel: 'Education',
+      summary: 'Formative Miami arts education (2009–2011).',
+      href: '/bio',
+    },
+  ] satisfies InstitutionOrg[],
   nextSteps: {
     title: 'How to work together',
     items: [
@@ -104,4 +496,6 @@ export const institutionsHub = {
       'Creative-technology programming and production support',
     ],
   },
+  honestyNote:
+    'Organizations listed above are verified through employment, residency, lab operations, workshops, exhibitions, platform builds, education, or funder credits documented on this site. Application-only relationships (for example YoungArts) are not listed as prior affiliations.',
 } as const;

--- a/src/content/institutions/hub.ts
+++ b/src/content/institutions/hub.ts
@@ -1,0 +1,107 @@
+/**
+ * /institutions — modular institutional portfolio hub.
+ */
+
+import { OOLITE_DIGITAL_LAB_IMAGE, OOLITE_DIGITAL_LAB_IMAGE_ALT } from '@/content/evidence/projects';
+import {
+  INSTITUTIONAL_AVAILABILITY,
+  INSTITUTIONAL_CALENDLY_URL,
+  type InstitutionalLane,
+} from './shared';
+
+const CDN = 'https://res.cloudinary.com/dck5rzi4h/image/upload';
+const BAKEHOUSE_IMAGE = `${CDN}/v1717960571/art/moisestech-website/digitaldivinities-moisesdsanabria-fabiolalarios-bakehouse-openstudios-spring-2024_f3ahbx.jpg`;
+
+export const institutionsHub = {
+  meta: {
+    title: 'Institutions — Artist-Centered Digital Systems | Moises Sanabria',
+    description:
+      'Embedded digital leadership, artist professional-development programs, institutional platforms and workflows, and creative-technology prototypes for cultural organizations.',
+    url: 'https://moises.tech/institutions',
+  },
+  hero: {
+    eyebrow: 'Institutional practice',
+    headline: 'I build artist-centered digital systems, programs, and experiences.',
+    lead:
+      'Not a generic availability pitch. A practice connecting programming, technology, infrastructure, and institutional operations—so artists can make work without becoming IT staff.',
+    availability: INSTITUTIONAL_AVAILABILITY,
+    primaryCta: {
+      label: 'Start an institutional conversation',
+      href: INSTITUTIONAL_CALENDLY_URL,
+      external: true,
+    },
+    secondaryCta: {
+      label: 'Email Moises',
+      href: 'mailto:m@moises.tech?subject=Institutional%20conversation%20%E2%80%94%20Moises%20Sanabria',
+    },
+  },
+  lanes: [
+    {
+      id: 'embedded-leadership',
+      title: 'Embedded digital and creative-technology leadership',
+      body: 'Fractional or term-based roles that connect labs, screens, documentation, and artist support into one coherent institutional system—not isolated projects.',
+      href: '/oolite-arts',
+      linkLabel: 'Oolite Arts case study',
+    },
+    {
+      id: 'artist-pd',
+      title: 'Artist professional-development programs',
+      body: 'Workshops, mentorship infrastructure, and career-stage resources designed for artists—operations, capacity, and craft together.',
+      href: '/artist-sustainability',
+      linkLabel: 'Artist sustainability portfolio',
+    },
+    {
+      id: 'platforms',
+      title: 'Institutional platforms, kiosks, and workflows',
+      body: 'SmartSigns, kiosk infrastructure, content systems, and proposed artist portals that make buildings and programs legible.',
+      href: '/bakehouse',
+      linkLabel: 'Bakehouse digital systems',
+    },
+    {
+      id: 'prototypes',
+      title: 'Creative-technology prototypes and public experiences',
+      body: 'Fabrication workflows, public installations, and educational toolkits that move from lab experiment to shared institutional capacity.',
+      href: '/workshops',
+      linkLabel: 'Bookable workshops',
+    },
+  ] satisfies InstitutionalLane[],
+  proof: {
+    title: 'Flagship proof',
+    intro: 'Start with the work already built inside Miami institutions.',
+    cards: [
+      {
+        id: 'oolite',
+        title: 'Oolite Arts Digital Lab',
+        body: 'Lab build and operations, workshops, equipment systems, documentation, and handoff.',
+        href: '/oolite-arts',
+        image: {
+          src: OOLITE_DIGITAL_LAB_IMAGE,
+          alt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
+          label: 'Lab context',
+          note: 'Production finished-lab photography pending.',
+        },
+      },
+      {
+        id: 'bakehouse',
+        title: 'Bakehouse Art Complex',
+        body: 'Shipped SmartSigns and kiosk infrastructure; Artist Portal proposed on Assembly; connected communications system next.',
+        href: '/bakehouse',
+        image: {
+          src: BAKEHOUSE_IMAGE,
+          alt: 'Bakehouse Art Complex — open studios and public-facing cultural context',
+          label: 'Building context',
+          note: 'Live SmartSign installation photo pending.',
+        },
+      },
+    ],
+  },
+  nextSteps: {
+    title: 'How to work together',
+    items: [
+      'Embedded / fractional digital leadership (6–12 months)',
+      'Paid workshop pilots and curriculum collaboration',
+      'Artist-facing platforms and institutional workflows',
+      'Creative-technology programming and production support',
+    ],
+  },
+} as const;

--- a/src/content/institutions/shared.ts
+++ b/src/content/institutions/shared.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared institutional outreach constants for Miami cultural partners.
+ */
+
+export const INSTITUTIONAL_CALENDLY_URL =
+  process.env.NEXT_PUBLIC_CALENDLY_URL ||
+  'https://calendly.com/moisestech/15-minute-meeting';
+
+export const INSTITUTIONAL_EMAIL = 'm@moises.tech';
+
+export const INSTITUTIONAL_AVAILABILITY =
+  'My year-long contract as Technical Director of Digital at Oolite Arts concludes September 17.';
+
+export type InstitutionalLane = {
+  id: string;
+  title: string;
+  body: string;
+  href: string;
+  linkLabel: string;
+};
+
+export type PlaceholderAsset = {
+  label: string;
+  note: string;
+  /** Optional existing image while production assets are prepared. */
+  src?: string;
+  alt?: string;
+};

--- a/src/content/institutions/workshopsOfferings.ts
+++ b/src/content/institutions/workshopsOfferings.ts
@@ -1,0 +1,42 @@
+/**
+ * Three bookable institutional workshop offerings for /workshops and outreach.
+ */
+
+import { INSTITUTIONAL_CALENDLY_URL } from './shared';
+
+export const institutionalWorkshopOfferings = {
+  intro: {
+    eyebrow: 'Bookable offerings',
+    title: 'Three workshops institutions can pilot',
+    lead:
+      'Designed for cultural organizations and artist communities. One Calendly for all three—tell me which offering fits your cohort.',
+    calendlyLabel: 'Book a planning call',
+    calendlyHref: INSTITUTIONAL_CALENDLY_URL,
+  },
+  offerings: [
+    {
+      id: 'vibe-coding',
+      title: 'Vibe Coding and Digital Presence for Artists',
+      body: 'Practical studio presence: sites, portfolios, and lightweight coding workflows artists can maintain—complementing entrepreneurial / web-presence curricula rather than competing with them.',
+      fits: 'FIU / RA+DI · MAD Arts · artist incubators',
+      relatedHref: '/workshop/own-your-digital-presence',
+      relatedLabel: 'Related digital presence program',
+    },
+    {
+      id: 'ai-automation',
+      title: 'AI and Automation for the Artist Studio',
+      body: 'Two-part pilot friendly: capture → summarize → publish patterns, agent literacy, and human review gates so automation serves authorship instead of erasing it.',
+      fits: 'MAD Arts pilot · Oolite-adjacent literacy · institutional PD',
+      relatedHref: '/workshop/the-art-of-ai-agents',
+      relatedLabel: 'Related AI agents workshop',
+    },
+    {
+      id: 'prototyping',
+      title: 'Creative Technology Prototyping and Digital Fabrication',
+      body: 'From idea to shared-facility prototype: fabrication literacy, documentation, and production workflows for artists using institutional labs.',
+      fits: 'Digital labs · fabrication programs · public workshops',
+      relatedHref: '/oolite-arts',
+      relatedLabel: 'Oolite Digital Lab proof',
+    },
+  ],
+} as const;

--- a/src/content/oolite-arts/case-study.ts
+++ b/src/content/oolite-arts/case-study.ts
@@ -1,0 +1,593 @@
+/**
+ * Oolite Arts Digital Lab — institutional case study content model.
+ * Components render from this data. Do not invent metrics, names, or outcomes.
+ */
+
+import {
+  OOLITE_DIGITAL_LAB_IMAGE,
+  OOLITE_DIGITAL_LAB_IMAGE_ALT,
+} from '@/content/evidence/projects';
+
+export type AssetStatus = 'ready' | 'needed' | 'placeholder';
+export type PermissionStatus =
+  | 'granted'
+  | 'unknown'
+  | 'anonymized'
+  | 'archetype-from-public-curriculum'
+  | 'public-source';
+
+export type NeededAsset = {
+  name: string;
+  preferred: string;
+  folder: string;
+  record: string;
+};
+
+export const OOLITE_ARTS_CASE_STUDY = {
+  meta: {
+    title: 'Oolite Arts Digital Lab — Institutional Case Study',
+    description:
+      'How Moises Sanabria and Fabiola Larios helped turn space, tools, curriculum, documentation, and sustained artist support into an accessible creative-technology program at Oolite Arts.',
+    url: 'https://moises.tech/oolite-arts',
+    ogImage: OOLITE_DIGITAL_LAB_IMAGE,
+  },
+
+  overview: {
+    title: 'Building an Artist-Centered Digital Lab',
+    subtitle:
+      'How we transformed space, tools, curriculum, documentation, and sustained artist support into an accessible creative-technology program for Miami artists.',
+    organization: 'Oolite Arts',
+    location: '924 Lincoln Rd., Studio 105 · Miami Beach, FL',
+    period: '2025–2026',
+    thesis:
+      'We did not simply operate equipment or teach isolated workshops. We helped turn a room, a collection of tools, and an institutional ambition into an artist-facing technology program.',
+    oneSentence:
+      'A digital lab becomes valuable not when an institution acquires equipment, but when artists can confidently use it to make, learn, experiment, and connect.',
+    supportingLine:
+      'Technical systems, classes, fabrication, artist support, and community access—designed as one connected program.',
+    credits: [
+      {
+        name: 'Fabiola Larios',
+        role: 'Digital Lab direction and co-development',
+      },
+      {
+        name: 'Moises Sanabria',
+        role: 'Technical direction and co-development',
+      },
+    ],
+    collaboration:
+      'In collaboration with Oolite staff, instructors, participating artists, and community learners.',
+    disclaimer:
+      'This independent case study documents work developed at Oolite Arts in collaboration with staff, artists, and participants. It is not an official Oolite Arts publication.',
+    publicLab: {
+      hours: 'Tuesday and Thursday, 10 a.m.–5 p.m.',
+      languages: 'English and Spanish',
+      support: 'Knight Foundation',
+      sourceUrl: 'https://oolitearts.org/event/digilab/',
+      sourceLabel: 'Oolite Arts — Digital Lab',
+    },
+    heroImage: {
+      src: OOLITE_DIGITAL_LAB_IMAGE,
+      alt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
+      status: 'placeholder' as AssetStatus,
+      note: 'Production hero pending dedicated finished-lab photography.',
+    },
+    neededHero360: {
+      name: 'Finished Digital Lab 360° panorama or walkthrough',
+      preferred: 'Equirectangular 2:1, 5.7K+ master; WebP/AVIF poster',
+      folder: 'public/oolite/360/',
+      record: 'assets.hero-360-01',
+    } satisfies NeededAsset,
+  },
+
+  institutionalQuestion: {
+    title: 'What does it take to make advanced technology genuinely useful to artists?',
+    lead:
+      'Working within limited time, evolving priorities, and the practical realities of cultural institutions, we focused on building systems that could make advanced tools accessible and repeatable.',
+    statements: [
+      'Equipment needs workflows',
+      'Workflows need documentation',
+      'Documentation needs teaching',
+      'Teaching needs trust',
+      'Trust grows through repeated support',
+    ],
+  },
+
+  beforeAfter: {
+    title: 'From room of tools to working program',
+    body: 'We treated the lab as more than a room of equipment. The work involved translating tools into repeatable systems: setup, safety, scheduling, onboarding, troubleshooting, teaching, and artist-facing support.',
+    pairs: [
+      {
+        id: 'before-after-lab',
+        label: 'Lab environment',
+        beforeLabel: 'Before',
+        afterLabel: 'After',
+        before: null,
+        after: {
+          src: OOLITE_DIGITAL_LAB_IMAGE,
+          alt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
+        },
+        needed: {
+          name: 'Matched before/after lab views (same camera position)',
+          preferred: 'Paired stills or synchronized video, identical framing',
+          folder: 'public/oolite/before-after/',
+          record: 'beforeAfter.pairs[0]',
+        } satisfies NeededAsset,
+      },
+    ],
+  },
+
+  systemLayers: [
+    {
+      id: 'space',
+      label: 'Space',
+      problem:
+        'A new Digital Lab at 924 needed clear artist flow—stations, storage, projection, and a room that could host classes and open lab without constant reinvention.',
+      intervention:
+        'Layout, workstation readiness, cable and storage discipline, and visitor flow planned around teaching and independent use.',
+      outcome:
+        'A room that can host workshops, open hours, and one-on-one support as one environment rather than competing setups.',
+      evidence: 'Public Digital Lab presence at Studio 105; program hours published by Oolite Arts.',
+    },
+    {
+      id: 'fabrication',
+      label: 'Fabrication',
+      problem:
+        'Digital fabrication tools do not become artist infrastructure until file prep, safety, queueing, and finishing are teachable and repeatable.',
+      intervention:
+        'Resin and related fabrication workflows: readiness checks, supervised demos, wash/cure awareness, and consultation pathways.',
+      outcome:
+        'Public programming such as Intro to 3D Resin Printing for Artists, with safety and process framed as institutional knowledge—not machine spectacle.',
+      evidence: 'Oolite Arts public class listing and workshop page (Aug 18, 2026).',
+    },
+    {
+      id: 'media',
+      label: 'Media',
+      problem:
+        'Documentation, livestream, and 360 capture risk becoming isolated deliverables unless tied to artist and institutional memory.',
+      intervention:
+        'Media practices connected to teaching, public archive ambitions, and artist-facing documentation habits.',
+      outcome:
+        'Lab identity that includes livestream archive and documentation as part of the public Digital Lab offering.',
+      evidence: 'Oolite Digital Lab public page — livestream archive and program language.',
+    },
+    {
+      id: 'software',
+      label: 'Software & workflows',
+      problem:
+        'Creative coding, AI tools, and website publishing overwhelm artists when presented as tools without a path to a finished, shareable artifact.',
+      intervention:
+        'Beginner-accessible curricula emphasizing experimentation, publishing, and personal expression over technical mastery theater.',
+      outcome:
+        'Workshops such as Artist Website for Beginners / Artist Websites for Beginners with explicit learning outcomes and published capacity.',
+      evidence: 'Oolite Arts public workshop pages (June 13 and Aug 29, 2026 listings).',
+    },
+    {
+      id: 'operations',
+      label: 'Operations & support',
+      problem:
+        'Without intake, scheduling, troubleshooting, safety, and hand-off documentation, classes become events instead of a program.',
+      intervention:
+        'Equipment readiness, artist intake patterns, supervised equipment use, curriculum templates, and follow-up consultation framing.',
+      outcome:
+        'Open lab hours, fee-based public workshops, and resident access described as connected parts of one Digital Lab.',
+      evidence: 'Oolite Arts Digital Lab public page; Technical Director / Director of Digital Lab roles publicly named.',
+    },
+  ],
+
+  resinWorkflow: {
+    title: '3D Resin Printing: From File to Object',
+    lead:
+      'Do not present the printer as spectacle alone. Show the institutional knowledge required to make it useful.',
+    steps: [
+      { id: 'concept', label: 'Artist concept or source image' },
+      { id: 'model', label: 'Digital model readiness' },
+      { id: 'slice', label: 'Slicing, supports, hollowing, drainage' },
+      { id: 'print', label: 'Supervised resin print' },
+      { id: 'wash', label: 'Wash and cure' },
+      { id: 'finish', label: 'Cleanup and finishing' },
+      { id: 'object', label: 'Completed artist object' },
+    ],
+    institutionalKnowledge: [
+      'File preparation and orientation',
+      'Safe handling and PPE',
+      'Failed-print diagnosis',
+      'Queue and material planning',
+      'Artist consultation',
+      'Finishing and hand-off',
+    ],
+    needed: {
+      name: 'Resin process clips + Draco-compressed GLB models',
+      preferred: '3–6 clips (10–30s); GLB under 10 MB; turntable photos',
+      folder: 'public/oolite/resin/',
+      record: 'resinWorkflow',
+    } satisfies NeededAsset,
+  },
+
+  classes: [
+    {
+      id: 'artist-website-beginners',
+      title: 'Artist Website for Beginners',
+      dateLabel: 'Saturday, June 13, 2026 · 10 a.m.–1 p.m.',
+      dateISO: '2026-06-13',
+      topics: ['artist-websites', 'creative-coding', 'net-art'],
+      audience: ['public', 'beginners'],
+      level: 'Beginners',
+      format: 'One-day workshop',
+      durationMinutes: 180,
+      capacity: 10,
+      age: '15+',
+      language: 'English',
+      location: 'Studio 100, 924 Lincoln Rd.',
+      instructors: ['Fabiola Larios', 'Moises Sanabria'],
+      summary:
+        'A beginner-friendly Digital Lab workshop exploring net art and building a simple website participants can personalize and share. No prior coding experience required.',
+      learningOutcomes: [
+        'Understand what net art is and how artists have used the web as a creative medium.',
+        'Learn the basics of editing HTML/CSS or template-based code in an approachable way.',
+        'Customize a webpage using text, images, color, layout, and links.',
+        'Publish or export a website project that can be shared.',
+        'Gain confidence using creative digital tools without prior programming experience.',
+      ],
+      tools: ['Creative coding tools', 'Web publishing platforms'],
+      sourceUrl: 'https://oolitearts.org/event/artist-website-for-beginners/',
+      sourceStatus: 'public-page-confirmed' as const,
+      image: {
+        src: 'https://res.cloudinary.com/dck5rzi4h/image/upload/v1782568215/dccmiami/workshops/vibe-coding-net-art/banners/02_beginner-artist-website-workflow_vibe-coding-digilab-oolite_m934yj.png',
+        alt: 'Beginner artist website workflow — Digilab Oolite workshop banner',
+        status: 'ready' as AssetStatus,
+      },
+      needed: {
+        name: 'Class photos (wide, detail, instructors, outcomes)',
+        preferred: '5–10 images, 2400px+ long edge, captioned',
+        folder: 'public/oolite/classes/artist-website-beginners/',
+        record: 'classes.artist-website-beginners',
+      } satisfies NeededAsset,
+    },
+    {
+      id: 'intro-resin-printing',
+      title: 'Intro to 3D Resin Printing for Artists',
+      dateLabel: 'Tuesday, Aug. 18, 2026 · 6–9 p.m.',
+      dateISO: '2026-08-18',
+      topics: ['3d-printing', 'digital-fabrication'],
+      audience: ['public', 'artists'],
+      level: 'All levels',
+      format: 'One-day workshop',
+      durationMinutes: 180,
+      capacity: 8,
+      age: '15+',
+      language: 'English',
+      location: 'Studio 106 (Fabrication Lab), 924 Lincoln Rd.',
+      instructors: ['Fabiola Larios', 'Moises Sanabria'],
+      summary:
+        'Hands-on introduction to the full resin workflow—file readiness, slicing, supports, wash/cure, safety, and realistic expectations—designed for sculpture, installation, prototyping, and object translation.',
+      learningOutcomes: [
+        'Understand what makes a file printable and why orientation and supports matter.',
+        'Observe supervised resin printer workflow and wash/cure post-processing.',
+        'Learn core safety procedures for resin, IPA, PPE, and waste handling.',
+        'Prepare for future one-on-one printing consultation or print appointment.',
+      ],
+      tools: ['Resin 3D printer', 'Wash/cure station', 'Slicing software'],
+      sourceUrl: 'https://oolitearts.org/event/intro-to-3d-resin-printing-for-artists/',
+      sourceStatus: 'public-page-confirmed' as const,
+      image: null,
+      needed: {
+        name: 'Resin class photos + process documentation',
+        preferred: '5–10 images; safety-aware framing; no unconsented faces',
+        folder: 'public/oolite/classes/intro-resin-printing/',
+        record: 'classes.intro-resin-printing',
+      } satisfies NeededAsset,
+    },
+    {
+      id: 'artist-websites-aug',
+      title: 'Artist Websites for Beginners',
+      dateLabel: 'Saturday, Aug. 29, 2026 · 10 a.m.–1 p.m.',
+      dateISO: '2026-08-29',
+      topics: ['artist-websites', 'creative-coding', 'net-art'],
+      audience: ['public', 'beginners'],
+      level: 'Beginners',
+      format: 'One-day workshop',
+      durationMinutes: 180,
+      capacity: null,
+      age: '15+',
+      language: 'English',
+      location: 'Oolite Arts Digital Lab programming',
+      instructors: ['Fabiola Larios', 'Moises Sanabria'],
+      summary:
+        'Listed in Oolite Arts adult class programming as a Digital Lab one-day workshop continuing the beginner website / creative publishing track.',
+      learningOutcomes: [],
+      tools: ['Web publishing platforms'],
+      sourceUrl: 'https://oolitearts.org/art-classes/',
+      sourceStatus: 'public-listing-confirmed' as const,
+      image: null,
+      needed: {
+        name: 'Class detail page confirmation + photos',
+        preferred: 'Link to event page when published; 5–10 photos',
+        folder: 'public/oolite/classes/artist-websites-aug/',
+        record: 'classes.artist-websites-aug',
+      } satisfies NeededAsset,
+    },
+  ],
+
+  artistStories: [
+    {
+      id: 'pattern-website',
+      anonymizedLabel: 'Support pattern · Artist website publishing',
+      wanted:
+        'A durable, shareable web presence or net-art page without needing to become a professional developer.',
+      obstacle:
+        'Coding confidence, hosting choices, and the gap between “having files” and publishing something personal online.',
+      support:
+        'Beginner Digital Lab workshop structure (HTML/CSS or templates, personalization, publish/export) plus consultation framing for continued iteration.',
+      result:
+        'Per public curriculum: participants leave with a shareable web-based artwork or personal site that can keep evolving.',
+      next: 'Follow-up open lab time and one-on-one support for extending the site.',
+      technologies: ['HTML/CSS', 'Web publishing', 'Net art'],
+      permissionStatus: 'archetype-from-public-curriculum' as PermissionStatus,
+      status: 'needs-consented-case-study',
+      needed: {
+        name: 'Consented artist mini case study (name optional)',
+        preferred: 'Need → obstacle → support → result; 2–4 images; written permission',
+        folder: 'public/oolite/artists/',
+        record: 'artistStories.pattern-website',
+      } satisfies NeededAsset,
+    },
+    {
+      id: 'pattern-resin',
+      anonymizedLabel: 'Support pattern · Resin object translation',
+      wanted:
+        'Translate a digital model or sculptural idea into a physical resin object for prototype, installation, or documentation.',
+      obstacle:
+        'File readiness, supports, safety, wash/cure, and realistic expectations about failure points.',
+      support:
+        'Full-workflow teaching with supervised equipment demos; safety procedures; path to future print appointments.',
+      result:
+        'Artists gain a process map from file to finished object—not only a demo of the machine running.',
+      next: 'One-on-one fabrication consultation or scheduled print support.',
+      technologies: ['Resin 3D printing', 'Slicing', 'Post-processing'],
+      permissionStatus: 'archetype-from-public-curriculum' as PermissionStatus,
+      status: 'needs-consented-case-study',
+      needed: {
+        name: 'Consented fabrication support story + object photos',
+        preferred: 'Process sequence; permission for artwork depiction',
+        folder: 'public/oolite/artists/',
+        record: 'artistStories.pattern-resin',
+      } satisfies NeededAsset,
+    },
+    {
+      id: 'pattern-open-lab',
+      anonymizedLabel: 'Support pattern · Open lab troubleshooting',
+      wanted:
+        'Use lab equipment or software during public / resident access hours to advance a live project.',
+      obstacle:
+        'Equipment readiness, file prep, and the last mile between workshop knowledge and independent use.',
+      support:
+        'Open lab hours, equipment readiness, troubleshooting, and hand-off documentation as ongoing infrastructure.',
+      result:
+        'Repeated access that builds trust—the condition under which advanced tools actually get used.',
+      next: 'Return visits, peer learning, and deeper project consultations.',
+      technologies: ['Lab operations', 'Documentation', 'Artist intake'],
+      permissionStatus: 'archetype-from-public-curriculum' as PermissionStatus,
+      status: 'needs-consented-case-study',
+      needed: {
+        name: 'Consented open-lab support story',
+        preferred: 'Anonymized OK; no private intake data',
+        folder: 'public/oolite/artists/',
+        record: 'artistStories.pattern-open-lab',
+      } satisfies NeededAsset,
+    },
+  ],
+
+  visibleInvisible: {
+    title: 'The Invisible Infrastructure',
+    lead:
+      'This is where a hiring manager or institutional director sees that we were not merely standing next to the machines—we helped design the operating system around them.',
+    visible: [
+      'Classes',
+      'Printers',
+      'Screens',
+      'Demonstrations',
+      'Finished objects',
+      'Artists experimenting',
+    ],
+    invisible: [
+      'Research',
+      'Equipment setup',
+      'Artist intake',
+      'Troubleshooting',
+      'Safety procedures',
+      'Scheduling',
+      'Curriculum development',
+      'Documentation',
+      'File preparation',
+      'Maintenance',
+      'Follow-up',
+      'Communication',
+    ],
+    neededDocs: {
+      name: 'Documentation screenshots (guides, schedules, workflows)',
+      preferred: '10–20 cropped screenshots; strip private data',
+      folder: 'public/oolite/documentation/',
+      record: 'visibleInvisible',
+    } satisfies NeededAsset,
+  },
+
+  metrics: {
+    asOfNote:
+      'Only publicly confirmed program facts are shown as numbers. Additional impact metrics will appear when verified against program records.',
+    items: [
+      {
+        id: 'lab-hours',
+        label: 'Published open lab days',
+        value: 'Tue & Thu',
+        detail: '10 a.m.–5 p.m.',
+        verified: true,
+        source: 'oolitearts.org/event/digilab/',
+      },
+      {
+        id: 'languages',
+        label: 'Languages supported',
+        value: '2',
+        detail: 'English and Spanish',
+        verified: true,
+        source: 'oolitearts.org/event/digilab/',
+      },
+      {
+        id: 'website-capacity',
+        label: 'Artist Website workshop capacity',
+        value: '10',
+        detail: 'June 13, 2026 public listing',
+        verified: true,
+        source: 'oolitearts.org/event/artist-website-for-beginners/',
+      },
+      {
+        id: 'resin-capacity',
+        label: 'Resin printing workshop capacity',
+        value: '8',
+        detail: 'Aug 18, 2026 public listing',
+        verified: true,
+        source: 'oolitearts.org/event/intro-to-3d-resin-printing-for-artists/',
+      },
+      {
+        id: 'classes-designed',
+        label: 'Classes designed',
+        value: null,
+        detail: 'Awaiting verified program record',
+        verified: false,
+        source: null,
+      },
+      {
+        id: 'artists-supported',
+        label: 'Artists supported',
+        value: null,
+        detail: 'Awaiting verified program record',
+        verified: false,
+        source: null,
+      },
+      {
+        id: 'consultations',
+        label: 'One-on-one consultations',
+        value: null,
+        detail: 'Awaiting verified program record',
+        verified: false,
+        source: null,
+      },
+      {
+        id: 'workflows-documented',
+        label: 'Equipment workflows documented',
+        value: null,
+        detail: 'Awaiting verified program record',
+        verified: false,
+        source: null,
+      },
+    ],
+  },
+
+  framework: {
+    title: 'A reusable model for cultural institutions',
+    steps: [
+      {
+        n: '01',
+        title: 'Listen',
+        body: 'Map artist, staff, and institutional needs.',
+      },
+      {
+        n: '02',
+        title: 'Connect',
+        body: 'Integrate space, hardware, software, and people.',
+      },
+      {
+        n: '03',
+        title: 'Translate',
+        body: 'Turn technical capacity into accessible programming.',
+      },
+      {
+        n: '04',
+        title: 'Support',
+        body: 'Provide sustained guidance beyond the workshop.',
+      },
+      {
+        n: '05',
+        title: 'Document',
+        body: 'Leave reusable systems and institutional memory.',
+      },
+    ],
+    cta: {
+      headline:
+        'Building a digital lab, artist-technology program, AI initiative, or creative learning platform?',
+      buttons: [
+        { label: 'Discuss an institutional project', href: '/contact' },
+        { label: 'View AI24', href: '/ai24' },
+        { label: 'View teaching', href: '/workshops' },
+        { label: 'Project inquiry', href: '/ai24#work-with-us' },
+      ],
+    },
+  },
+
+  narrativeArc: [
+    {
+      title: 'The opportunity',
+      body: 'A new lab, new equipment, and a mandate to support artists.',
+    },
+    {
+      title: 'The challenge',
+      body: 'Tools do not automatically become programs, workflows, or community.',
+    },
+    {
+      title: 'The transformation',
+      body: 'We connected physical space, technical systems, curriculum, documentation, and human support.',
+    },
+    {
+      title: 'The activity',
+      body: 'Workshops, open lab support, prototyping, artist projects, and public engagement.',
+    },
+    {
+      title: 'The outcomes',
+      body: 'Skills transferred, projects advanced, infrastructure documented, and a reusable institutional model created.',
+    },
+    {
+      title: 'The next application',
+      body: 'This methodology can be adapted for museums, residencies, universities, nonprofits, and creative companies.',
+    },
+  ],
+
+  credits: {
+    roles: [
+      {
+        name: 'Fabiola Larios',
+        role: 'Director of Digital Lab · direction and co-development',
+        website: 'https://fabiola.io',
+      },
+      {
+        name: 'Moises Sanabria',
+        role: 'Technical Director · technical direction and co-development',
+        website: 'https://moises.tech',
+      },
+    ],
+    collective:
+      'Oolite Arts staff, instructors, participating artists, and community learners.',
+    organization: 'Oolite Arts',
+    funderNote: 'Digital Lab public materials credit generous support from the Knight Foundation.',
+    sources: [
+      {
+        label: 'Digital Lab — Oolite Arts',
+        href: 'https://oolitearts.org/event/digilab/',
+      },
+      {
+        label: 'Artist Website for Beginners — Oolite Arts',
+        href: 'https://oolitearts.org/event/artist-website-for-beginners/',
+      },
+      {
+        label: 'Intro to 3D Resin Printing for Artists — Oolite Arts',
+        href: 'https://oolitearts.org/event/intro-to-3d-resin-printing-for-artists/',
+      },
+      {
+        label: 'Adult Art Classes — Oolite Arts',
+        href: 'https://oolitearts.org/art-classes/',
+      },
+    ],
+    lastUpdated: '2026-08-04',
+    phaseNote:
+      'Phase 1 case study. Phase 2 will add 360° viewer, synchronized before/after video, filterable class database, interactive resin models, and community mosaic when assets are ready.',
+  },
+} as const;


### PR DESCRIPTION
## Summary
- Merge Oolite Arts Phase 1 case study at `/oolite-arts`
- Add modular institutional hub at `/institutions` with verified orgs + case studies
- Add `/bakehouse` (shipped / proposed on Assembly / future embedded role)
- Add private noindex `/artist-sustainability` YoungArts supplement
- Reframe `/workshops` with three bookable institutional offerings + Calendly

## Test plan
- [ ] `/institutions` loads with org filters and case study grid
- [ ] `/oolite-arts`, `/bakehouse`, `/artist-sustainability`, `/workshops` resolve
- [ ] `/artist-sustainability` is `noindex`
- [ ] Calendly CTAs point at moisestech calendly
- [ ] Mobile/desktop scan of hub + Bakehouse buckets


Made with [Cursor](https://cursor.com)