### PR TITLE
Pilot pricing + DCC Miami Bakehouse framing

### DIFF
--- a/src/components/institutions/BakehousePageClient.tsx
+++ b/src/components/institutions/BakehousePageClient.tsx
@@ -56,6 +56,43 @@ export function BakehousePageClient() {
         </InstContainer>
       </header>
 
+      <section
+        id="thesis"
+        className="scroll-mt-24 border-b border-neutral-200 py-12 sm:py-16"
+        aria-labelledby="thesis-heading"
+      >
+        <InstContainer>
+          <InstSectionLabel>{B.thesis.eyebrow}</InstSectionLabel>
+          <h2 id="thesis-heading" className="max-w-3xl font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+            {B.thesis.title}
+          </h2>
+          <p className="mt-4 max-w-3xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+            {B.thesis.body}
+          </p>
+          <ul className="mt-6 grid gap-2 sm:grid-cols-2">
+            {B.thesis.points.map((point) => (
+              <li
+                key={point}
+                className="border-l-2 border-neutral-950 bg-white/70 py-2.5 pl-3 text-sm leading-relaxed text-neutral-800"
+              >
+                {point}
+              </li>
+            ))}
+          </ul>
+          <p className="mt-6 text-sm text-neutral-600">
+            Artist-owned practice:{' '}
+            <a
+              href={B.thesis.dcc.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold underline underline-offset-4"
+            >
+              {B.thesis.dcc.fullName} ({B.thesis.dcc.name})
+            </a>
+          </p>
+        </InstContainer>
+      </section>
+
       <div className="space-y-0">
         {B.buckets.map((bucket) => (
           <section
@@ -110,7 +147,7 @@ export function BakehousePageClient() {
           <p className="mt-4 max-w-3xl text-sm leading-relaxed text-neutral-700 sm:text-base">
             {B.ask.body}
           </p>
-          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
             <InstPrimaryCta
               href={B.ask.primaryCta.href}
               label={B.ask.primaryCta.label}
@@ -118,6 +155,11 @@ export function BakehousePageClient() {
               onClick={() => track('cta_institutions_click', { source: 'bakehouse_ask' })}
             />
             <InstSecondaryCta href={B.ask.secondaryCta.href} label={B.ask.secondaryCta.label} />
+            <InstSecondaryCta
+              href={B.ask.tertiaryCta.href}
+              label={B.ask.tertiaryCta.label}
+              external={B.ask.tertiaryCta.external}
+            />
           </div>
         </InstContainer>
       </section>
@@ -127,9 +169,20 @@ export function BakehousePageClient() {
           <ul className="flex flex-wrap gap-x-6 gap-y-2 text-sm">
             {B.related.map((item) => (
               <li key={item.href}>
-                <Link href={item.href} className="font-medium underline-offset-4 hover:underline">
-                  {item.label}
-                </Link>
+                {'external' in item && item.external ? (
+                  <a
+                    href={item.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium underline-offset-4 hover:underline"
+                  >
+                    {item.label}
+                  </a>
+                ) : (
+                  <Link href={item.href} className="font-medium underline-offset-4 hover:underline">
+                    {item.label}
+                  </Link>
+                )}
               </li>
             ))}
           </ul>

--- a/src/components/institutions/InstitutionsHubClient.tsx
+++ b/src/components/institutions/InstitutionsHubClient.tsx
@@ -18,6 +18,7 @@ import {
   InstSecondaryCta,
   InstSectionLabel,
 } from '@/components/institutions/InstitutionalUi';
+import { ProposePilotBand } from '@/components/institutions/PilotPricingBand';
 import { cn } from '@/lib/utils';
 
 const H = institutionsHub;
@@ -239,6 +240,10 @@ export function InstitutionsHubClient() {
           </dl>
         </InstContainer>
       </header>
+
+      <InstContainer className="py-8 sm:py-10">
+        <ProposePilotBand />
+      </InstContainer>
 
       <nav
         className="sticky top-0 z-30 border-b border-neutral-200 bg-[#f7f6f3]/90 backdrop-blur"

--- a/src/components/institutions/PilotPricingBand.tsx
+++ b/src/components/institutions/PilotPricingBand.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import Link from 'next/link';
+import { institutionalWorkshopOfferings } from '@/content/institutions/workshopsOfferings';
+import { PILOT_PRICING } from '@/content/institutions/shared';
+import { track } from '@/lib/analytics';
+import {
+  InstPrimaryCta,
+  InstSectionLabel,
+} from '@/components/institutions/InstitutionalUi';
+import { cn } from '@/lib/utils';
+
+type PilotPricingBandProps = {
+  /** Use denser layout inside workshops dark hub. */
+  tone?: 'dossier' | 'hub';
+  className?: string;
+  showCta?: boolean;
+  source?: string;
+};
+
+/**
+ * Oolite-aligned seat + hosted flat pricing for institutional pilots.
+ */
+export function PilotPricingBand({
+  tone = 'dossier',
+  className,
+  showCta = true,
+  source = 'pilot_pricing',
+}: PilotPricingBandProps) {
+  const pricing = institutionalWorkshopOfferings.pricing;
+  const dark = tone === 'hub';
+
+  return (
+    <section
+      className={cn(
+        dark
+          ? 'rounded-xl border border-white/10 bg-white/5 p-5 sm:p-6'
+          : 'border border-neutral-200 bg-white p-5 sm:p-6',
+        className,
+      )}
+      aria-labelledby="pilot-pricing-heading"
+    >
+      {dark ? (
+        <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.18em] text-white/50 sm:text-xs">
+          {pricing.eyebrow}
+        </p>
+      ) : (
+        <InstSectionLabel>{pricing.eyebrow}</InstSectionLabel>
+      )}
+      <h2
+        id="pilot-pricing-heading"
+        className={cn(
+          "font-['MoMA_Sans'] text-xl font-semibold sm:text-2xl",
+          dark ? 'text-white' : 'text-neutral-950',
+        )}
+      >
+        {pricing.title}
+      </h2>
+      <p
+        className={cn(
+          'mt-2 max-w-2xl text-sm leading-relaxed',
+          dark ? 'text-white/75' : 'text-neutral-700',
+        )}
+      >
+        {pricing.lead}
+      </p>
+      <a
+        href={pricing.sourceUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={cn(
+          'mt-2 inline-block text-xs font-medium underline underline-offset-4',
+          dark ? 'text-cyan-300' : 'text-neutral-600',
+        )}
+      >
+        {pricing.sourceLabel}
+      </a>
+
+      <ul className="mt-6 grid gap-3 sm:grid-cols-3">
+        {pricing.packages.map((pkg) => (
+          <li
+            key={pkg.id}
+            className={cn(
+              'border p-4',
+              dark ? 'border-white/15 bg-black/20' : 'border-neutral-200 bg-[#f7f6f3]',
+            )}
+          >
+            <p
+              className={cn(
+                'font-mono text-[10px] uppercase tracking-[0.14em]',
+                dark ? 'text-white/50' : 'text-neutral-500',
+              )}
+            >
+              {pkg.label}
+            </p>
+            <p
+              className={cn(
+                "mt-2 font-['MoMA_Sans'] text-2xl font-semibold",
+                dark ? 'text-white' : 'text-neutral-950',
+              )}
+            >
+              {pkg.price}
+            </p>
+            <p className={cn('mt-1 text-xs leading-relaxed', dark ? 'text-white/70' : 'text-neutral-600')}>
+              {pkg.detail}
+            </p>
+            <p className={cn('mt-2 text-xs leading-relaxed', dark ? 'text-white/55' : 'text-neutral-500')}>
+              {pkg.note}
+            </p>
+          </li>
+        ))}
+      </ul>
+
+      {showCta ? (
+        <div className="mt-6">
+          <InstPrimaryCta
+            href={PILOT_PRICING.calendlyHref}
+            label={PILOT_PRICING.calendlyLabel}
+            external
+            onClick={() => track('cta_institutions_click', { source })}
+          />
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+type ProposePilotBandProps = {
+  className?: string;
+};
+
+/** Hub CTA: parallel pilot outreach — calendar responders. */
+export function ProposePilotBand({ className }: ProposePilotBandProps) {
+  return (
+    <section
+      className={cn('border border-neutral-950 bg-neutral-950 px-5 py-8 text-white sm:px-8 sm:py-10', className)}
+      aria-labelledby="propose-pilot-heading"
+    >
+      <p className="mb-3 font-mono text-[11px] uppercase tracking-[0.18em] text-white/55 sm:text-xs">
+        Parallel outreach
+      </p>
+      <h2 id="propose-pilot-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+        Propose a pilot—we’ll coordinate who responds
+      </h2>
+      <p className="mt-3 max-w-2xl text-sm leading-relaxed text-white/75 sm:text-base">
+        Same three offerings go to multiple Miami institutions at once. Pricing stays Oolite-aligned (
+        {PILOT_PRICING.seat.display} / seat, or {PILOT_PRICING.hostedFlat.display} hosted). Calendar follows
+        replies—not a single pre-picked winner.
+      </p>
+      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+        <a
+          href={PILOT_PRICING.calendlyHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex min-h-11 items-center justify-center bg-white px-5 py-2.5 text-sm font-semibold text-neutral-950"
+          onClick={() => track('cta_institutions_click', { source: 'institutions_propose_pilot' })}
+        >
+          {PILOT_PRICING.calendlyLabel}
+        </a>
+        <Link
+          href="/workshops"
+          className="inline-flex min-h-11 items-center justify-center border border-white/40 px-5 py-2.5 text-sm font-medium text-white"
+        >
+          View offerings & pricing
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/components/page/WorkshopClient.tsx
+++ b/src/components/page/WorkshopClient.tsx
@@ -26,6 +26,7 @@ import { motion } from 'framer-motion'
 import { WORKSHOP_HUB, CALENDLY_URL } from '@/constants/workshop-hub'
 import { WORKSHOP_FEATURES, type WorkshopCardVisual } from '@/constants/workshop-features'
 import { institutionalWorkshopOfferings } from '@/content/institutions/workshopsOfferings'
+import { PilotPricingBand } from '@/components/institutions/PilotPricingBand'
 import { track } from '@/lib/analytics'
 import { useTheme } from '@/contexts/ThemeContext'
 import { cn } from '@/lib/utils'
@@ -332,12 +333,17 @@ export default function WorkshopClient() {
               <ArrowUpRight className="h-4 w-4" aria-hidden />
             </a>
           </div>
+          <PilotPricingBand tone="hub" className="mb-6 sm:mb-8" source="workshops_pricing" />
           <ul className="grid grid-cols-1 gap-4 md:grid-cols-3">
             {institutionalWorkshopOfferings.offerings.map((offering) => (
               <li key={offering.id} className={cn(cardBase)}>
                 <h3 className={cn('text-base sm:text-lg font-bold leading-snug', heading)}>
                   {offering.title}
                 </h3>
+                <p className={cn('mt-2 text-[11px] font-semibold uppercase tracking-wide', accentIcon)}>
+                  {offering.duration}
+                </p>
+                <p className={cn('mt-1 text-sm font-semibold', heading)}>{offering.priceLabel}</p>
                 <p className={cn('mt-3 text-xs sm:text-sm leading-relaxed flex-1', bodyMuted)}>
                   {offering.body}
                 </p>

--- a/src/content/institutions/bakehouse.ts
+++ b/src/content/institutions/bakehouse.ts
@@ -1,9 +1,11 @@
 /**
  * /bakehouse — institutional digital systems page for Bakehouse Art Complex.
  * Clearly separate shipped work, proposed work, and future opportunity.
+ * Ask: part-time embedded (negotiable) via artist-owned practice DCC Miami.
  */
 
 import {
+  DCC_MIAMI,
   INSTITUTIONAL_AVAILABILITY,
   INSTITUTIONAL_CALENDLY_URL,
   type PlaceholderAsset,
@@ -14,16 +16,16 @@ const BAKEHOUSE_IMAGE = `${CDN}/v1717960571/art/moisestech-website/digitaldivini
 
 export const bakehousePage = {
   meta: {
-    title: 'Bakehouse Art Complex — Digital Systems | Moises Sanabria',
+    title: 'Bakehouse Art Complex — Digital Lab Systems | Moises Sanabria · DCC Miami',
     description:
-      'SmartSigns and kiosk infrastructure shipped at Bakehouse Art Complex; Artist Portal proposed on Assembly; a connected institutional communication system as the next layer.',
+      'SmartSigns and kiosk infrastructure shipped at Bakehouse; Artist Portal proposed on Assembly; part-time embedded digital leadership through artist-owned practice DCC Miami.',
     url: 'https://moises.tech/bakehouse',
   },
   hero: {
-    eyebrow: 'Bakehouse Art Complex',
-    headline: 'Digital systems that make an artist building legible.',
+    eyebrow: 'Bakehouse Art Complex · DCC Miami',
+    headline: 'An artist-owned Digital Lab model—inside the building artists already use.',
     lead:
-      'Screens, workflows, and artist-facing infrastructure—so studios, events, and public life stay connected without turning artists into systems administrators.',
+      'We already proved the lab model at Oolite: tools, workshops, documentation, and artist support as one system. At Bakehouse, the next step is standing up that same coherence—screens, portal, programming, and ops—through DCC Miami, an artist-owned practice, in a part-time embedded partnership.',
     availability: INSTITUTIONAL_AVAILABILITY,
     image: {
       src: BAKEHOUSE_IMAGE,
@@ -32,12 +34,24 @@ export const bakehousePage = {
       note: 'Production SmartSign installation photos pending; this image is contextual Bakehouse work.',
     } satisfies PlaceholderAsset & { src: string; alt: string },
   },
+  thesis: {
+    eyebrow: 'Why this ask',
+    title: 'Not another isolated project—an artist-owned lab practice',
+    body: `The goal is to promote and extend the Digital Lab approach we built and operated: artist-facing technology that institutions can trust. ${DCC_MIAMI.fullName} (${DCC_MIAMI.name}) is the artist-owned name for that practice—partnering with Bakehouse on part-time embedded digital leadership, negotiable in scope and schedule.`,
+    points: [
+      'Proof first: SmartSigns / Anthias already shipping in the building',
+      'Next layer: Artist Portal on Assembly for content governance',
+      'Operating model: DCC Miami as artist-owned practice + Bakehouse as host institution',
+      'Engagement: part-time embedded / fractional—negotiable, not a generic staff IT hire',
+    ],
+    dcc: DCC_MIAMI,
+  },
   buckets: [
     {
       id: 'shipped',
       status: 'Shipped',
       title: 'SmartSigns, kiosks, and display infrastructure',
-      body: 'Vertical smart-sign systems and Raspberry Pi / Anthias-based display workflows that promote artists, events, and studio activity through a repeatable screen format. Handoff of Anthias/SmartSigns operations is in progress.',
+      body: 'Vertical smart-sign systems and Raspberry Pi / Anthias-based display workflows that promote artists, events, and studio activity through a repeatable screen format. Handoff of Anthias/SmartSigns operations is in progress—completion is the trust gate for the leadership conversation.',
       items: [
         'Artist and event promotion on vertical screens',
         'Raspberry Pi / Anthias display stack',
@@ -76,38 +90,44 @@ export const bakehousePage = {
     {
       id: 'future',
       status: 'Future opportunity',
-      title: 'A connected institutional communication system',
-      body: 'The next layer is not another isolated tool. It is coherence: SmartSigns, Artist Portal, artist communications, digital programming, and technical infrastructure operating as one system under embedded digital leadership.',
+      title: 'Bakehouse Digital Lab — connected communications + programming',
+      body: 'Coherence under part-time embedded leadership via DCC Miami: SmartSigns, Artist Portal, artist communications, digital programming, and technical infrastructure as one artist-centered system—the same class of work as the Oolite Digital Lab, adapted to Bakehouse.',
       items: [
         'Shared content model across screens, portal, and programming',
-        'Clear roles for staff, artists, and contractors',
+        'Clear roles for Bakehouse staff, artists, and DCC Miami',
         'Documentation and handoff so the system survives turnover',
-        '6–12 month embedded / fractional digital leadership option',
+        'Part-time embedded engagement—scope and schedule negotiable',
       ],
       placeholders: [
         {
           label: 'System map diagram',
-          note: 'One diagram: screens ↔ Assembly portal ↔ programming ↔ ops.',
+          note: 'One diagram: screens ↔ Assembly portal ↔ programming ↔ DCC Miami ops.',
         },
       ] satisfies PlaceholderAsset[],
     },
   ],
   ask: {
     title: 'Conversation for Bakehouse leadership',
-    body: 'Rather than proposing another isolated project, the useful next step is an embedded part-time role or six-to-twelve-month engagement focused on digital strategy, artist technology, and institutional systems.',
+    body: `Rather than proposing another isolated tool, I’d like to discuss a part-time embedded partnership—negotiable—between Bakehouse and ${DCC_MIAMI.name}: digital strategy, artist technology, and institutional systems that promote a Digital Lab culture artists already recognize from Oolite.`,
     primaryCta: {
       label: 'Schedule 30 minutes',
       href: INSTITUTIONAL_CALENDLY_URL,
       external: true,
     },
     secondaryCta: {
-      label: 'Related Oolite proof',
+      label: 'Oolite Digital Lab proof',
       href: '/oolite-arts',
+    },
+    tertiaryCta: {
+      label: `${DCC_MIAMI.name} site`,
+      href: DCC_MIAMI.href,
+      external: true,
     },
   },
   related: [
     { label: 'Institutions hub', href: '/institutions' },
     { label: 'SmartSign service page', href: '/services/smartsign' },
     { label: 'Oolite Arts case study', href: '/oolite-arts' },
+    { label: DCC_MIAMI.name, href: DCC_MIAMI.href, external: true },
   ],
 } as const;

--- a/src/content/institutions/hub.ts
+++ b/src/content/institutions/hub.ts
@@ -325,11 +325,12 @@ export const institutionsHub = {
     },
     {
       id: 'dcc',
-      name: 'Digital Culture Center Miami',
+      name: 'Digital Culture Center Miami (DCC Miami)',
       location: 'Miami, FL',
       relationship: 'platform',
-      relationshipLabel: ORG_RELATIONSHIP_LABELS.platform,
-      summary: 'Institutional website and digital infrastructure for cultural programming.',
+      relationshipLabel: 'Artist-owned practice · Platform',
+      summary:
+        'Artist-owned cultural-technology practice—institutional platforms and the operating name for embedded Digital Lab partnerships (including the Bakehouse conversation).',
       href: 'https://dcc.miami',
       external: true,
       imageSrc: DCC.imageSrc,

--- a/src/content/institutions/shared.ts
+++ b/src/content/institutions/shared.ts
@@ -11,6 +11,46 @@ export const INSTITUTIONAL_EMAIL = 'm@moises.tech';
 export const INSTITUTIONAL_AVAILABILITY =
   'My year-long contract as Technical Director of Digital at Oolite Arts concludes September 17.';
 
+/** Artist-owned cultural-technology practice operating as DCC Miami. */
+export const DCC_MIAMI = {
+  name: 'DCC Miami',
+  fullName: 'Digital Culture Center Miami',
+  href: 'https://dcc.miami',
+  label: 'Artist-owned practice',
+} as const;
+
+/**
+ * Public seat pricing aligned with current Oolite Arts Digital Lab workshops
+ * (Artist Websites / Vibe Coding / Resin — publicly listed at $45 / ~3hr).
+ */
+export const PILOT_PRICING = {
+  sourceNote:
+    'Aligned with current Oolite Arts Digital Lab public workshop pricing ($45 / participant / ~3 hours).',
+  sourceUrl: 'https://oolitearts.org/event/artist-websites-for-beginners/',
+  seat: {
+    amount: 45,
+    display: '$45',
+    unit: 'per participant / ~3 hours',
+    capacityTypical: '8–10 participants',
+  },
+  hostedFlat: {
+    min: 360,
+    max: 450,
+    display: '$360–$450',
+    unit: 'flat institutional host rate for one 3-hour session (8–10 seats)',
+    mathNote: 'Same economics as $45 × 8–10 seats; institution hosts the cohort.',
+  },
+  twoPart: {
+    min: 720,
+    max: 900,
+    display: '$720–$900',
+    unit: 'two-part pilot (2 × 3 hours) for 8–10 seats',
+    mathNote: 'Double the single-session flat range; toolkit can be scoped separately.',
+  },
+  calendlyLabel: 'Book a planning call',
+  calendlyHref: INSTITUTIONAL_CALENDLY_URL,
+} as const;
+
 export type InstitutionalLane = {
   id: string;
   title: string;

--- a/src/content/institutions/workshopsOfferings.ts
+++ b/src/content/institutions/workshopsOfferings.ts
@@ -1,23 +1,56 @@
 /**
  * Three bookable institutional workshop offerings for /workshops and outreach.
+ * Pricing mirrors current Oolite Arts Digital Lab public rates.
  */
 
-import { INSTITUTIONAL_CALENDLY_URL } from './shared';
+import { INSTITUTIONAL_CALENDLY_URL, PILOT_PRICING } from './shared';
 
 export const institutionalWorkshopOfferings = {
   intro: {
     eyebrow: 'Bookable offerings',
     title: 'Three workshops institutions can pilot',
     lead:
-      'Designed for cultural organizations and artist communities. One Calendly for all three—tell me which offering fits your cohort.',
-    calendlyLabel: 'Book a planning call',
+      'Designed for cultural organizations and artist communities. Propose the same offerings in parallel—we’ll coordinate calendar with whoever responds. One Calendly for planning.',
+    calendlyLabel: PILOT_PRICING.calendlyLabel,
     calendlyHref: INSTITUTIONAL_CALENDLY_URL,
+  },
+  pricing: {
+    eyebrow: 'Pricing',
+    title: 'Oolite-aligned pilot rates',
+    lead: PILOT_PRICING.sourceNote,
+    sourceUrl: PILOT_PRICING.sourceUrl,
+    sourceLabel: 'Oolite Arts — public workshop listing',
+    packages: [
+      {
+        id: 'seat',
+        label: 'Public / participant seat',
+        price: PILOT_PRICING.seat.display,
+        detail: PILOT_PRICING.seat.unit,
+        note: PILOT_PRICING.seat.capacityTypical,
+      },
+      {
+        id: 'hosted',
+        label: 'Institutional host — single session',
+        price: PILOT_PRICING.hostedFlat.display,
+        detail: PILOT_PRICING.hostedFlat.unit,
+        note: PILOT_PRICING.hostedFlat.mathNote,
+      },
+      {
+        id: 'two-part',
+        label: 'Two-part institutional pilot',
+        price: PILOT_PRICING.twoPart.display,
+        detail: PILOT_PRICING.twoPart.unit,
+        note: PILOT_PRICING.twoPart.mathNote,
+      },
+    ],
   },
   offerings: [
     {
       id: 'vibe-coding',
       title: 'Vibe Coding and Digital Presence for Artists',
       body: 'Practical studio presence: sites, portfolios, and lightweight coding workflows artists can maintain—complementing entrepreneurial / web-presence curricula rather than competing with them.',
+      duration: '3 hours · one session',
+      priceLabel: `${PILOT_PRICING.seat.display} / seat · or ${PILOT_PRICING.hostedFlat.display} hosted`,
       fits: 'FIU / RA+DI · MAD Arts · artist incubators',
       relatedHref: '/workshop/own-your-digital-presence',
       relatedLabel: 'Related digital presence program',
@@ -26,6 +59,8 @@ export const institutionalWorkshopOfferings = {
       id: 'ai-automation',
       title: 'AI and Automation for the Artist Studio',
       body: 'Two-part pilot friendly: capture → summarize → publish patterns, agent literacy, and human review gates so automation serves authorship instead of erasing it.',
+      duration: '2 × 3 hours · recommended pilot',
+      priceLabel: `${PILOT_PRICING.twoPart.display} hosted (8–10 seats)`,
       fits: 'MAD Arts pilot · Oolite-adjacent literacy · institutional PD',
       relatedHref: '/workshop/the-art-of-ai-agents',
       relatedLabel: 'Related AI agents workshop',
@@ -34,6 +69,8 @@ export const institutionalWorkshopOfferings = {
       id: 'prototyping',
       title: 'Creative Technology Prototyping and Digital Fabrication',
       body: 'From idea to shared-facility prototype: fabrication literacy, documentation, and production workflows for artists using institutional labs.',
+      duration: '3 hours · one session',
+      priceLabel: `${PILOT_PRICING.seat.display} / seat · or ${PILOT_PRICING.hostedFlat.display} hosted`,
       fits: 'Digital labs · fabrication programs · public workshops',
       relatedHref: '/oolite-arts',
       relatedLabel: 'Oolite Digital Lab proof',


### PR DESCRIPTION
## Summary
- Follow-up to merged PR #7
- Oolite-aligned pricing: **$45/seat** and **$360–$450** hosted (8–10), plus two-part **$720–$900**
- `/institutions` parallel “propose a pilot” CTA
- `/bakehouse` reframed as part-time embedded / negotiable via **DCC Miami** (artist-owned Digital Lab model)
- `/workshops` shows pricing band + per-offering duration/price

## Test plan
- [ ] `/workshops` shows three pricing packages + offering cards with prices
- [ ] `/institutions` shows propose-pilot band
- [ ] `/bakehouse` leads with DCC Miami / artist-owned thesis
- [ ] Calendly CTAs still work


Made with [Cursor](https://cursor.com)