### PR TITLE
Upgrade DAVID/Ogilvy Creative Editor dossier

### DIFF
--- a/docs/life-os.md
+++ b/docs/life-os.md
@@ -20,8 +20,8 @@ Read path from this repo into the personal **LIFE OS** Airtable base used for jo
 
 ### Needs build (ordered)
 
-1. **Vercel env** — set `AIRTABLE_LIFE_OS_API_KEY` + `LIFE_OS_READ_TOKEN` on moises production (local already works).
-2. **Opportunities → dossiers** — map LIFE OS Opportunities rows to `/opportunities/[slug]` tracker status (one source of truth for applications).
+1. ~~Vercel env~~ — **optional**. LIFE OS is for local agent read/write; production dossiers do not need Airtable on Vercel.
+2. **Opportunities → dossiers** — map LIFE OS Opportunities rows to `/opportunities/[slug]` tracker status (local PM spine).
 3. **Write/claim port** — today write ops live in infra24; port only if agents should claim from moises.
 4. **Optional tables** — People, Organizations, Interactions, Revenue (discover already lists them).
 5. **Rotate PAT** — token was pasted in chat; regenerate when convenient.

--- a/next.config.js
+++ b/next.config.js
@@ -198,6 +198,12 @@ const nextConfig = {
       },
       {
         protocol: 'https',
+        hostname: 'i.ytimg.com',
+        port: '',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
         hostname: 'www.blind-magazine.com',
         port: '',
         pathname: '/**',

--- a/src/components/opportunities/RoleReferenceAccordion.tsx
+++ b/src/components/opportunities/RoleReferenceAccordion.tsx
@@ -50,6 +50,16 @@ export function RoleReferenceAccordion({
                 </div>
               ))}
             </dl>
+            {data.narrativeSections?.length ? (
+              <div className="mt-6 space-y-5 border-t border-stone-100 pt-5 dark:border-stone-800">
+                {data.narrativeSections.map((section) => (
+                  <div key={section.heading}>
+                    <p className={opp.label}>{section.heading}</p>
+                    <p className={`mt-1.5 max-w-3xl ${opp.body}`}>{section.body}</p>
+                  </div>
+                ))}
+              </div>
+            ) : null}
             <p className={`mt-5 ${opp.label}`}>Core platform references</p>
             <ul className="mt-2 flex flex-wrap gap-1.5">
               {data.platformReferences.map((ref) => (

--- a/src/components/opportunities/creative-agency/CreativeAgencyClient.tsx
+++ b/src/components/opportunities/creative-agency/CreativeAgencyClient.tsx
@@ -10,6 +10,9 @@ import { FitPillars } from '@/components/opportunities/FitPillars';
 import { RoleMatchMatrix } from '@/components/opportunities/RoleMatchMatrix';
 import { CapabilityMap } from '@/components/opportunities/CapabilityMap';
 import { ResumeCTA } from '@/components/opportunities/ResumeCTA';
+import { SkillsMatrix } from '@/components/opportunities/SkillsMatrix';
+import { InnovationProcess } from '@/components/opportunities/InnovationProcess';
+import { RoleReferenceAccordion } from '@/components/opportunities/RoleReferenceAccordion';
 import { CreativeCaseStudyModules } from '@/components/opportunities/creative-agency/CreativeCaseStudyModules';
 import { CampaignChannelSystem } from '@/components/opportunities/creative-agency/CampaignChannelSystem';
 import { HumanAiWorkflow } from '@/components/opportunities/creative-agency/HumanAiWorkflow';
@@ -35,6 +38,8 @@ export function CreativeAgencyClient({ opportunity }: CreativeAgencyClientProps)
   const dossier = opportunity.rolePortfolio;
   const agency = opportunity.creativeAgency;
   const hasBanner = Boolean(opportunity.applicationBanner?.src);
+  const hasSkills = Boolean(opportunity.skillsMatrixRows?.length);
+  const hasProcess = Boolean(opportunity.processSteps?.length);
 
   if (!dossier || !agency) {
     return (
@@ -46,7 +51,7 @@ export function CreativeAgencyClient({ opportunity }: CreativeAgencyClientProps)
     );
   }
 
-  const sectionClass = 'mt-8 sm:mt-10 md:mt-14';
+  const sectionClass = 'mt-12 sm:mt-14 md:mt-20';
   const framed = '!mt-0 !border-0 !pt-0 scroll-mt-28 sm:scroll-mt-32';
 
   return (
@@ -86,12 +91,18 @@ export function CreativeAgencyClient({ opportunity }: CreativeAgencyClientProps)
           <OpportunityHero opportunity={opportunity} />
         </OpportunityColorSection>
 
+        {opportunity.roleReference ? (
+          <div className="mt-8 sm:mt-10">
+            <RoleReferenceAccordion data={opportunity.roleReference} />
+          </div>
+        ) : null}
+
         {opportunity.navItems?.length ? (
-          <div className="mt-6 sm:mt-8">
+          <div className="mt-8 sm:mt-10">
             <DossierSectionNav
               items={opportunity.navItems.filter((item) => item.id !== 'hero')}
               title="Dossier map"
-              intro="Tap any section to jump. Sticky nav at the top stays in sync as you scroll. Amber labels mark placeholders—nothing unfinished is presented as shipped client work."
+              intro="Jump to any section. Sticky nav at the top stays in sync as you scroll."
             />
           </div>
         ) : null}
@@ -105,6 +116,12 @@ export function CreativeAgencyClient({ opportunity }: CreativeAgencyClientProps)
             className={framed}
           />
         </OpportunityColorSection>
+
+        {hasSkills ? (
+          <OpportunityColorSection sectionId="skills" className={sectionClass}>
+            <SkillsMatrix opportunity={opportunity} framed />
+          </OpportunityColorSection>
+        ) : null}
 
         <OpportunityColorSection sectionId="case-studies" className={sectionClass}>
           <CreativeCaseStudyModules
@@ -131,6 +148,12 @@ export function CreativeAgencyClient({ opportunity }: CreativeAgencyClientProps)
               sectionId="motion"
               className={framed}
             />
+          </OpportunityColorSection>
+        ) : null}
+
+        {hasProcess ? (
+          <OpportunityColorSection sectionId="process" className={sectionClass}>
+            <InnovationProcess opportunity={opportunity} sectionId="process" framed layout="horizontal" />
           </OpportunityColorSection>
         ) : null}
 

--- a/src/components/opportunities/creative-agency/MotionAndAnimationSection.tsx
+++ b/src/components/opportunities/creative-agency/MotionAndAnimationSection.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { AssetPlaceholder } from '@/components/opportunities/creative-agency/AssetPlaceholder';
 import { OpportunityCardImage } from '@/components/opportunities/OpportunityCardImage';
 import { opp } from '@/components/opportunities/opportunityTheme';
-import type { MotionSection } from '@/content/opportunities/creativeAgencyDossier';
+import type { MotionClip, MotionSection } from '@/content/opportunities/creativeAgencyDossier';
 import { cn } from '@/lib/utils';
 
 type MotionAndAnimationSectionProps = {
@@ -13,70 +13,113 @@ type MotionAndAnimationSectionProps = {
   className?: string;
 };
 
+function ClipMedia({ clip }: { clip: MotionClip }) {
+  if (clip.youtubeId) {
+    return (
+      <iframe
+        title={clip.title}
+        src={`https://www.youtube-nocookie.com/embed/${clip.youtubeId}?rel=0`}
+        className="absolute inset-0 h-full w-full"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerPolicy="strict-origin-when-cross-origin"
+        allowFullScreen
+        loading="lazy"
+      />
+    );
+  }
+
+  if (clip.videoSrc) {
+    return (
+      <video
+        className="h-full w-full object-cover"
+        controls
+        playsInline
+        preload="metadata"
+        poster={clip.posterSrc}
+      >
+        <source src={clip.videoSrc} />
+      </video>
+    );
+  }
+
+  if (clip.posterLocal || !clip.posterSrc.startsWith('http')) {
+    return <OpportunityCardImage src={clip.posterSrc} alt={clip.posterAlt} local />;
+  }
+
+  return (
+    <Image
+      src={clip.posterSrc}
+      alt={clip.posterAlt}
+      fill
+      className="object-cover"
+      sizes="(max-width: 768px) 100vw, 50vw"
+    />
+  );
+}
+
+function ClipCard({ clip, featured }: { clip: MotionClip; featured?: boolean }) {
+  return (
+    <li
+      className={cn(
+        'overflow-hidden border border-stone-200 bg-white dark:border-stone-700 dark:bg-stone-950',
+        featured && 'sm:col-span-2',
+      )}
+    >
+      <div className="relative aspect-video bg-stone-100 dark:bg-stone-900">
+        <ClipMedia clip={clip} />
+      </div>
+      <div className={cn('p-4 sm:p-5', featured && 'sm:p-6')}>
+        <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-amber-800 dark:text-amber-300">
+          {clip.roleLabel}
+        </p>
+        <h3 className={cn(opp.h3, 'mt-1.5')}>{clip.title}</h3>
+        <p className={cn(opp.body, 'mt-2 text-sm', featured && 'max-w-3xl sm:text-base')}>
+          {clip.contribution}
+        </p>
+        {clip.placeholderNote ? (
+          <div className="mt-3">
+            <AssetPlaceholder
+              badge="Clip pending"
+              title="Motion file not attached yet"
+              note={clip.placeholderNote}
+              aspectClass="aspect-auto min-h-0 py-3"
+            />
+          </div>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
 export function MotionAndAnimationSection({
   data,
   sectionId = 'motion',
   className,
 }: MotionAndAnimationSectionProps) {
+  const featured = data.clips.filter((c) => c.featured);
+  const rest = data.clips.filter((c) => !c.featured);
+
   return (
     <section id={sectionId} className={cn(opp.section, className)}>
       <h2 className={opp.h2}>{data.title}</h2>
       <p className={cn(opp.body, 'mt-3 max-w-3xl')}>{data.intro}</p>
       <p className={cn(opp.subtle, 'mt-2 max-w-3xl')}>{data.toolsLine}</p>
 
-      <ul className="mt-8 grid gap-6 sm:grid-cols-2">
-        {data.clips.map((clip) => (
-          <li
-            key={clip.id}
-            className="overflow-hidden border border-stone-200 bg-white dark:border-stone-700 dark:bg-stone-950"
-          >
-            <div className="relative aspect-video bg-stone-100 dark:bg-stone-900">
-              {clip.videoSrc ? (
-                <video
-                  className="h-full w-full object-cover"
-                  controls
-                  playsInline
-                  preload="metadata"
-                  poster={clip.posterSrc}
-                >
-                  <source src={clip.videoSrc} />
-                </video>
-              ) : clip.posterLocal || !clip.posterSrc.startsWith('http') ? (
-                <OpportunityCardImage
-                  src={clip.posterSrc}
-                  alt={clip.posterAlt}
-                  local
-                />
-              ) : (
-                <Image
-                  src={clip.posterSrc}
-                  alt={clip.posterAlt}
-                  fill
-                  className="object-cover"
-                  sizes="(max-width: 768px) 100vw, 50vw"
-                />
-              )}
-            </div>
-            <div className="p-4 sm:p-5">
-              <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-amber-800 dark:text-amber-300">
-                {clip.roleLabel}
-              </p>
-              <h3 className={cn(opp.h3, 'mt-1.5')}>{clip.title}</h3>
-              <p className={cn(opp.body, 'mt-2 text-sm')}>{clip.contribution}</p>
-              {clip.placeholderNote ? (
-                <div className="mt-3">
-                  <AssetPlaceholder
-                    badge="Clip pending"
-                    title="Motion file not attached yet"
-                    note={clip.placeholderNote}
-                    aspectClass="aspect-auto min-h-0 py-3"
-                  />
-                </div>
-              ) : null}
-            </div>
-          </li>
-        ))}
-      </ul>
+      {featured.length ? (
+        <ul className="mt-8 grid gap-6">
+          {featured.map((clip) => (
+            <ClipCard key={clip.id} clip={clip} featured />
+          ))}
+        </ul>
+      ) : null}
+
+      {rest.length ? (
+        <ul className={cn('grid gap-6 sm:grid-cols-2', featured.length ? 'mt-6' : 'mt-8')}>
+          {rest.map((clip) => (
+            <ClipCard key={clip.id} clip={clip} />
+          ))}
+        </ul>
+      ) : null}
     </section>
   );
 }

--- a/src/content/applications/opportunityTracker.ts
+++ b/src/content/applications/opportunityTracker.ts
@@ -240,7 +240,7 @@ export const opportunityTracker: ApplicationTrack[] = [
   // —— Still to apply (priority order) ——
   {
     id: 'ogilvy-creative-editor-ai',
-    company: 'Ogilvy',
+    company: 'DAVID / Ogilvy',
     role: 'Creative Editor/AI',
     status: 'to_apply',
     priority: 1,
@@ -248,7 +248,8 @@ export const opportunityTracker: ApplicationTrack[] = [
     slug: 'ogilvy-senior-ai-driven-creative-director',
     aliasSlug: 'ogilvy-senior-ai-driven-creative-editor',
     employerUrl: 'https://www.linkedin.com/jobs/view/creative-editor-ai-at-ogilvy-4400258835',
-    notes: 'Canonical slug is creative-director; editor URL redirects. Next application.',
+    notes:
+      'DAVID Agency (WPP/Ogilvy) · Miami · posted 08/04/2026. Dossier embeds All Studios Everything (18M+). Need official DAVID/Ogilvy/WPP logos if available.',
   },
   {
     id: 'alpha-drive-full-stack',
@@ -437,6 +438,68 @@ export const opportunityTracker: ApplicationTrack[] = [
     status: 'hold',
     family: 'none',
     employerUrl: 'https://www.newmuseum.org/work-with-us/',
+  },
+
+  // —— Registry sync (pages exist; keep tracker complete) ——
+  {
+    id: 'affirm-ai-solutions-engineer',
+    company: 'Affirm',
+    role: 'AI Solutions Engineer',
+    status: 'to_apply',
+    family: 'systems',
+    slug: 'affirm-ai-solutions-engineer',
+    archetype: 'ai-solutions-architect',
+    notes: 'Systems dossier live; listed archetype-adjacent.',
+  },
+  {
+    id: 'flora-founding-data-engineer',
+    company: 'FLORA',
+    role: 'Founding Data Engineer',
+    status: 'to_apply',
+    family: 'role-portfolio',
+    slug: 'flora-founding-data-engineer',
+    archetype: 'ai-engineer',
+    notes: 'Private role-portfolio with honest Coming soon gaps.',
+  },
+  {
+    id: 'knight-journalism-tech-product-strategist',
+    company: 'Knight Foundation',
+    role: 'Technology Product Strategist, Journalism',
+    status: 'earlier',
+    family: 'full',
+    slug: 'knight-journalism-tech-product-strategist',
+    archetype: 'institutional',
+    notes: 'Canonical dossier at /technology-product-strategy.',
+  },
+  {
+    id: 'new-inc-media-fabrication-lab-manager',
+    company: 'NEW INC',
+    role: 'Media and Fabrication Lab Manager',
+    status: 'to_apply',
+    family: 'compact',
+    slug: 'new-inc-media-fabrication-lab-manager',
+    archetype: 'institutional',
+    notes: 'Institutional compact dossier; Digilab-adjacent proof.',
+  },
+  {
+    id: 'playwire-return',
+    company: 'Playwire',
+    role: 'Data · Solutions · Product Engineering (return)',
+    status: 'to_apply',
+    family: 'compact',
+    slug: 'playwire',
+    archetype: 'ai-solutions-architect',
+    notes: 'Private return dossier.',
+  },
+  {
+    id: 'wmx-senior-art-director-ai-driven-design-leader',
+    company: 'WMX',
+    role: 'Senior Art Director, AI-Driven Design Leader',
+    status: 'to_apply',
+    family: 'creative-agency',
+    slug: 'wmx-senior-art-director-ai-driven-design-leader',
+    archetype: 'creative',
+    notes: 'Sibling of wmx-senior-art-director-ai — differentiate or merge later.',
   },
 
   // —— Earlier 2025 prep (no confirmation) ——

--- a/src/content/evidence/recruitingLogoBand.ts
+++ b/src/content/evidence/recruitingLogoBand.ts
@@ -121,3 +121,39 @@ export const floraDataEngineerSkillLogoBand: LogoBandItem[] = [
   { src: 'https://cdn.simpleicons.org/amazonaws/FF9900', alt: 'AWS', height: 36 },
   { src: 'https://cdn.simpleicons.org/github', alt: 'GitHub', height: 36 },
 ];
+
+/**
+ * Creative Editor / AI stack — Adobe craft + generative tools named in agency listings.
+ * Swap in official Midjourney / Runway / Firefly / VEO marks when brand assets are cleared.
+ */
+export const creativeAiSkillLogoBand: LogoBandItem[] = [
+  {
+    src: 'https://cdn.simpleicons.org/adobephotoshop/31A8FF',
+    alt: 'Adobe Photoshop',
+    height: 36,
+  },
+  {
+    src: 'https://cdn.simpleicons.org/adobeillustrator/FF9A00',
+    alt: 'Adobe Illustrator',
+    height: 36,
+  },
+  { src: 'https://cdn.simpleicons.org/adobeindesign/FF3366', alt: 'Adobe InDesign', height: 36 },
+  {
+    src: 'https://cdn.simpleicons.org/adobeaftereffects/9999FF',
+    alt: 'Adobe After Effects',
+    height: 36,
+  },
+  {
+    src: 'https://cdn.simpleicons.org/adobepremierepro/9999FF',
+    alt: 'Adobe Premiere Pro',
+    height: 36,
+  },
+  { src: 'https://cdn.simpleicons.org/adobe/FF0000', alt: 'Adobe Firefly', height: 36 },
+  { src: 'https://cdn.simpleicons.org/figma/F24E1E', alt: 'Figma', height: 36 },
+  { src: `${jobsCdn}/v1778692505/jobs/open-ai-logo_vvvlks.png`, alt: 'OpenAI', height: 36 },
+  { src: 'https://cdn.simpleicons.org/google/4285F4', alt: 'Google AI / VEO 3', height: 36 },
+  { src: '/images/tech-logos/comfyui.svg', alt: 'ComfyUI', height: 36 },
+  { src: 'https://cdn.simpleicons.org/youtube/FF0000', alt: 'YouTube', height: 36 },
+  { src: 'https://cdn.simpleicons.org/instagram/E4405F', alt: 'Instagram', height: 36 },
+  { src: 'https://cdn.simpleicons.org/tiktok', alt: 'TikTok', height: 36 },
+];

--- a/src/content/opportunities/createCreativeAgencyOpportunity.ts
+++ b/src/content/opportunities/createCreativeAgencyOpportunity.ts
@@ -2,8 +2,10 @@
  * Helper to assemble creative-agency opportunity dossiers with shared chrome.
  */
 
-import type { ApplicationBanner, Opportunity, RoleMatchRow } from './types';
+import type { ApplicationBanner, Opportunity, RoleMatchRow, SkillsMatrixRow } from './types';
 import type { CreativeAgencyDossier } from './creativeAgencyDossier';
+import type { RoleReferenceData } from '@/content/opportunities/systemsDossier';
+import type { LogoBandItem } from '@/content/evidence/recruitingLogoBand';
 import {
   creativeAgencyNavItems,
   creativeAgencySkillsMatrix,
@@ -40,8 +42,15 @@ export type CreativeAgencyOpportunityConfig = {
   navItems?: Opportunity['navItems'];
   evidenceRecipe?: Opportunity['evidenceRecipe'];
   caseStudiesIntro?: string;
-  /** Live send URL for packet CTA. Default `/career-packet` until `/creative-ai` is deployed. */
+  /** Live send URL for packet CTA. */
   careerPacketHref?: string;
+  animatedLogoBand?: LogoBandItem[];
+  skillsMatrixRows?: SkillsMatrixRow[];
+  /** Expandable listing snapshot (JD meta). */
+  roleReference?: RoleReferenceData;
+  companyLogoSrc?: string;
+  companyLogoSrcDark?: string;
+  companyLogoAlt?: string;
 };
 
 export function createCreativeAgencyOpportunity(
@@ -95,7 +104,7 @@ export function createCreativeAgencyOpportunity(
     featuredProjectIds: [...creativeProofPack.featuredProjectIds],
     evidenceRecipe: config.evidenceRecipe,
     caseStudiesIntro: config.caseStudiesIntro,
-    skillsMatrixRows: creativeAgencySkillsMatrix,
+    skillsMatrixRows: config.skillsMatrixRows ?? creativeAgencySkillsMatrix,
     processSectionTitle: `How I would work at ${config.company}`,
     processIntro:
       config.processIntro ??
@@ -109,6 +118,11 @@ export function createCreativeAgencyOpportunity(
       emailSubject: config.emailSubject,
     }),
     techLogoIds: [],
+    animatedLogoBand: config.animatedLogoBand,
+    roleReference: config.roleReference,
+    companyLogoSrc: config.companyLogoSrc,
+    companyLogoSrcDark: config.companyLogoSrcDark,
+    companyLogoAlt: config.companyLogoAlt,
     resumeSectionTitle: agency.ctaHeadline,
     resumeSectionNote:
       config.resumeSectionNote ??

--- a/src/content/opportunities/creativeAgencyDossier.ts
+++ b/src/content/opportunities/creativeAgencyDossier.ts
@@ -114,14 +114,18 @@ export type MotionClip = {
   roleLabel: string;
   /** What you did: animation, edit, composite, keyframes, etc. */
   contribution: string;
-  /** Poster / still — required. */
+  /** Poster / still — required (also used as YouTube poster fallback). */
   posterSrc: string;
   posterAlt: string;
   posterLocal?: boolean;
   /** Optional hosted video URL (Cloudinary / Mux / Vimeo). */
   videoSrc?: string;
+  /** YouTube video id — renders privacy-enhanced embed when set. */
+  youtubeId?: string;
   /** Honest note when clip is pending upload. */
   placeholderNote?: string;
+  /** Full-width featured treatment (e.g. high-view count YouTube proof). */
+  featured?: boolean;
 };
 
 export type MotionSection = {

--- a/src/content/opportunities/ogilvy-senior-ai-driven-creative-director.ts
+++ b/src/content/opportunities/ogilvy-senior-ai-driven-creative-director.ts
@@ -1,10 +1,10 @@
 /**
- * Ogilvy — Creative Editor / AI
+ * Ogilvy / DAVID Agency — Creative Editor / AI
  * Canonical: /opportunities/ogilvy-senior-ai-driven-creative-director
  * Alias:     /opportunities/ogilvy-senior-ai-driven-creative-editor → redirect
  *
- * Listing: Creative Editor/AI (Miami-active). Banner may still say Creative Director.
- * Do not invent Ogilvy client work or network title history.
+ * Listing: Creative Editor/AI · DAVID Agency (WPP / Ogilvy network) · Miami · posted 08/04/2026
+ * Do not invent Ogilvy or DAVID client work or network title history.
  *
  * Submission surface: no recruiter-visible TODO / Placeholder tiles.
  */
@@ -13,45 +13,176 @@ import { createCreativeAgencyOpportunity } from './createCreativeAgencyOpportuni
 import {
   buildCampaignSystem,
   buildCreativeAgencyDossier,
+  creativeAgencyNavItems,
   miamiLightCampaignSpecimens,
   OOLITE_DIGITAL_LAB_IMAGE,
   OOLITE_DIGITAL_LAB_IMAGE_ALT,
   submissionCreativeCaseStudies,
   submissionCreativeWorkflow,
 } from './creativeAgencyShared';
+import type { MotionSection } from './creativeAgencyDossier';
+import type { RoleReferenceData } from '@/content/opportunities/systemsDossier';
+import type { SkillsMatrixRow } from '@/content/opportunities/types';
 import { evidenceProjects } from '@/content/evidence/projects';
 import { ogilvySeniorAiDrivenCreativeDirectorBanner } from '@/content/evidence/applicationBanners';
+import { creativeAiSkillLogoBand } from '@/content/evidence/recruitingLogoBand';
 
 /** Listing title on LinkedIn; keep slug stable for existing links. */
 const ROLE_TITLE = 'Creative Editor / AI';
 const COMPANY = 'Ogilvy';
 const lore = evidenceProjects['lore-machine'];
 const ai24 = evidenceProjects.ai24;
+const multimodal = evidenceProjects['multimodal-image-systems'];
+
+const ALL_STUDIOS_EVERYTHING_YT = 'XuSwUBULiQs';
+const ALL_STUDIOS_POSTER = `https://i.ytimg.com/vi/${ALL_STUDIOS_EVERYTHING_YT}/hqdefault.jpg`;
+
+const ogilvyMotionSection: MotionSection = {
+  title: 'Motion, edit & viral craft',
+  intro:
+    'Editorial and motion proof for a Creative Editor/AI seat: culture-native video that earns attention, then production systems that keep taste and brand intact under AI acceleration.',
+  toolsLine:
+    'YouTube · Premiere · After Effects · generative stills → edit · platform-native pacing · human review before publish',
+  clips: [
+    {
+      id: 'all-studios-everything',
+      title: 'All Studios Everything',
+      roleLabel: 'Creator · Edit · Direction · 18M+ views',
+      contribution:
+        'Original YouTube piece with 18M+ views—scroll-stopping concept, edit rhythm, and cultural hook. Proof that platform-native storytelling can scale without abandoning craft.',
+      posterSrc: ALL_STUDIOS_POSTER,
+      posterAlt: 'All Studios Everything — YouTube thumbnail',
+      youtubeId: ALL_STUDIOS_EVERYTHING_YT,
+      featured: true,
+    },
+    {
+      id: 'generative-to-edit',
+      title: 'Generative still → editorial cut',
+      roleLabel: 'AI exploration · Edit · Compositing',
+      contribution:
+        'Controlled generative exploration refined into editorial pacing—human direction at every gate so AI expands options without owning the final cut.',
+      posterSrc: multimodal.imageSrc,
+      posterAlt: multimodal.imageAlt,
+    },
+    {
+      id: 'ai24-editorial-pipeline',
+      title: 'AI24 editorial review pipeline',
+      roleLabel: 'Editorial systems · Review gates',
+      contribution:
+        'Product and editorial surfaces where generative drafts require critique before publish—the same discipline an agency Creative Editor/AI seat needs under brand guidelines.',
+      posterSrc: ai24.imageSrc,
+      posterAlt: ai24.imageAlt,
+    },
+  ],
+};
+
+const ogilvySkillsMatrix: SkillsMatrixRow[] = [
+  {
+    category: 'Editorial + AI production',
+    skills:
+      'Concept → script → execution with AI as accelerator; human critique on taste, brand voice, and cultural precision',
+    icon: 'sparkles',
+  },
+  {
+    category: 'Visual design & art direction',
+    skills: 'Branding, visual systems, decks, print, information design, UX sensibility',
+    icon: 'image',
+  },
+  {
+    category: 'AI creative tools',
+    skills:
+      'Google AI / VEO 3, OpenAI, Adobe Firefly, Runway-class video, ComfyUI, prompt systems, compositing under human review',
+    icon: 'cpu',
+  },
+  {
+    category: 'Adobe craft',
+    skills:
+      'Expert Photoshop, Illustrator, InDesign (+ Premiere / After Effects finish) — shippable files, not prompt screenshots',
+    icon: 'layers',
+  },
+  {
+    category: 'Social & platform-native',
+    skills: 'Hooks, formats, repurposing across channels; trend → brief → asset with performance awareness',
+    icon: 'tv',
+  },
+  {
+    category: 'Leadership & mentorship',
+    skills: 'Directing creators, workshops, critique culture, cross-functional translation (creative ↔ product ↔ leadership)',
+    icon: 'users',
+  },
+];
+
+const ogilvyRoleReference: RoleReferenceData = {
+  title: 'Listing snapshot — expand for role meta & network context',
+  fields: [
+    { label: 'Role', value: 'Creative Editor / AI' },
+    { label: 'Agency', value: 'DAVID Agency (Ogilvy / WPP network)' },
+    { label: 'Location', value: 'Miami' },
+    { label: 'Posted', value: '08/04/2026' },
+    { label: 'Focus', value: 'Digital creative + AI production leadership' },
+    { label: 'Experience signal', value: '7+ years visual design, art direction, creative strategy' },
+  ],
+  narrativeSections: [
+    {
+      heading: 'About DAVID',
+      body: 'DAVID is a global creative boutique (founded 2012) with offices including Miami, New York, Madrid, Buenos Aires, São Paulo, and Bogotá. Part of WPP and Ogilvy’s global creative network, it is known for high-craft campaigns and festival recognition (Cannes Lions, EFFIEs, Agency of the Year honors). This dossier does not claim prior DAVID client work.',
+    },
+    {
+      heading: 'About Ogilvy',
+      body: 'Ogilvy, part of WPP, builds Borderless Creativity across advertising, PR, relationship design, consulting, and health—ranked #1 global agency network for creative excellence and effectiveness by WARC. The Creative Editor/AI seat sits inside that craft standard.',
+    },
+    {
+      heading: 'About WPP',
+      body: 'WPP is the parent network powering media, creativity, production, and enterprise solutions—including the agentic marketing platform WPP Open. Network context only; not an employment claim.',
+    },
+  ],
+  platformReferences: [
+    'Adobe Photoshop / Illustrator / InDesign',
+    'Adobe Firefly',
+    'Google AI / VEO 3',
+    'OpenAI',
+    'Runway-class video tools',
+    'Premiere / After Effects',
+    'Social & video storytelling',
+  ],
+  listingUrl: 'https://www.linkedin.com/jobs/view/creative-editor-ai-at-ogilvy-4400258835',
+  listingUrlLabel: 'LinkedIn listing',
+};
 
 const creativeAgency = buildCreativeAgencyDossier({
   capabilitiesIntro:
-    'Capabilities framed for a Creative Editor/AI seat: editorial judgment, generative production under review, and systems that protect brand voice and story craft.',
+    'Built for DAVID’s Creative Editor/AI seat: originate AI-native concepts, lead production workflows, protect brand craft, and mentor creators—under Borderless Creativity, not tool novelty.',
   caseStudiesIntro:
-    'Three shipped proof lines—product generative systems, institutional enablement, and editorial AI literacy. Self-initiated channel study below is labeled; not Ogilvy client work.',
+    'Three shipped proof lines—product generative systems, institutional enablement, and editorial AI literacy. Self-initiated channel study below is labeled; not DAVID or Ogilvy client work.',
   caseStudies: submissionCreativeCaseStudies,
   workflow: submissionCreativeWorkflow,
   campaign: buildCampaignSystem({
     conceptTitle: 'Working concept — editorial clarity, brand-safe AI craft',
     conceptBody:
-      'A self-initiated campaign system showing how a strong visual idea moves from exploration to channel crops under critique—built to demonstrate Ogilvy-adjacent editorial discipline, not to claim Ogilvy client work.',
+      'A self-initiated campaign system showing how a strong visual idea moves from exploration to channel crops under critique—built to demonstrate DAVID/Ogilvy-adjacent editorial discipline, not to claim network client work.',
     eyebrow: 'Self-Initiated Brand-Safe AI Campaign Study',
     intro:
       'Ready channel specimens from one master still. Additional formats stay off this page until they are finished—no placeholder tiles on the submission surface.',
     disclaimer:
-      'Self-initiated study for application evidence. Not an Ogilvy client project. Specimens shown are Ready crops of the master still.',
+      'Self-initiated study for application evidence. Not a DAVID or Ogilvy client project. Specimens shown are Ready crops of the master still.',
     specimens: miamiLightCampaignSpecimens,
     readyOnly: true,
   }),
+  motionSection: ogilvyMotionSection,
   alignmentTitle: 'Role alignment',
   alignmentIntro:
-    'Ogilvy Creative Editor/AI priorities mapped to demonstrated practice. Do not read this as prior Ogilvy employment or network ACD title history.',
-  ctaHeadline: 'Let’s put AI in service of editorial craft—not the other way around.',
+    'Creative Editor/AI priorities from the Miami listing mapped to demonstrated practice. Do not read this as prior DAVID or Ogilvy employment.',
+  ctaHeadline: 'Let’s put AI in service of editorial craft—at DAVID speed.',
 });
+
+const ogilvyNavItems = [
+  ...creativeAgencyNavItems.slice(0, 2),
+  { id: 'skills', label: 'Skills & tools', shortLabel: 'Skills' },
+  ...creativeAgencyNavItems.slice(2, 5),
+  { id: 'motion', label: 'Motion & YouTube', shortLabel: 'Motion' },
+  { id: 'process', label: 'How I’d work', shortLabel: 'Process' },
+  ...creativeAgencyNavItems.slice(5),
+];
 
 export const ogilvySeniorAiDrivenCreativeDirectorOpportunity = createCreativeAgencyOpportunity({
   slug: 'ogilvy-senior-ai-driven-creative-director',
@@ -60,72 +191,99 @@ export const ogilvySeniorAiDrivenCreativeDirectorOpportunity = createCreativeAge
   evidenceRecipe: 'wpp-hex',
   caseStudiesIntro:
     'PRIMARY Creative AI proof · SECONDARY Forward-Deployed enablement · SUPPORTING Agentic Ops (Building). Same flagships, agency ordering.',
-  seoTitle: 'Moises Sanabria — Ogilvy · Creative Editor / AI',
+  seoTitle: 'Moises Sanabria — DAVID / Ogilvy · Creative Editor / AI',
   seoDescription:
-    'Application dossier for Ogilvy Creative Editor/AI — editorial judgment, human-directed generative systems, and brand craft.',
+    'Application dossier for DAVID Agency Creative Editor/AI (Ogilvy / WPP) — editorial judgment, AI production leadership, and brand craft. Includes All Studios Everything (18M+ views).',
   banner: ogilvySeniorAiDrivenCreativeDirectorBanner,
-  heroEyebrow: 'APPLICATION DOSSIER · OGILVY · MIAMI',
+  heroEyebrow: 'APPLICATION DOSSIER · DAVID · OGILVY / WPP · MIAMI',
   headline: 'Editorial craft first. AI as production acceleration.',
-  subheadline: `${ROLE_TITLE} · Selected work for Ogilvy`,
+  subheadline: `${ROLE_TITLE} · DAVID Agency · Selected work for Ogilvy`,
   introParagraphs: [
-    'I’m a Miami-based interdisciplinary artist and design technologist. I lead editorial and visual systems where generative tools expand exploration while human critique protects taste, narrative clarity, brand integrity, and cultural precision—the standard an Ogilvy Creative Editor/AI seat requires.',
+    'I’m a Miami-based interdisciplinary artist and design technologist applying for Creative Editor/AI at DAVID Agency (Ogilvy’s global creative network / WPP). I lead editorial and visual systems where generative tools expand exploration while human critique protects taste, narrative clarity, brand integrity, and cultural precision.',
+    'What you’ll get: end-to-end ownership from concept and scripting to AI-accelerated execution, platform-native social craft, Adobe finishing, and the judgment to say no when a generative draft fails the brief—plus proof that culture-native video can scale (All Studios Everything, 18M+ views).',
   ],
-  trustLine: 'Lore Machine · AI24 · Oolite Arts · Cooper Union BFA',
+  trustLine: 'All Studios Everything · Lore Machine · AI24 · Oolite Arts · Cooper Union BFA',
   heroMetaChips: [
     'Editorial + AI production',
-    'Brand voice under review',
+    'DAVID / Miami',
+    '18M+ view YouTube proof',
     'Adobe finishing',
-    'Cross-functional translation',
-    'Miami-active',
+    'Social & video storytelling',
+    'Mentor creators',
   ],
   audienceTerms: [
     {
-      label: 'Ogilvy',
-      detail: 'Global creative network — ideas, brand craft, and emerging technology under discipline.',
+      label: 'DAVID Agency',
+      detail: 'Global creative boutique in the Ogilvy / WPP network — Cannes-caliber craft with Miami presence.',
+    },
+    {
+      label: 'Ogilvy / WPP',
+      detail: 'Borderless Creativity — advertising, PR, relationship design, and emerging tech under one network.',
     },
     {
       label: 'Creative Editor / AI',
-      detail: 'Editorial judgment with generative production fluency—not tool novelty alone.',
+      detail: 'Lead AI-integrated creative execution: concepts, workflows, social systems, and creator mentorship.',
     },
     {
       label: 'Human review',
-      detail: 'Pipelines that require critique before publish.',
+      detail: 'Pipelines that require critique before publish — AI accelerates; taste decides.',
     },
   ],
   creativeAgency,
+  navItems: ogilvyNavItems,
+  animatedLogoBand: creativeAiSkillLogoBand,
+  skillsMatrixRows: ogilvySkillsMatrix,
+  roleReference: ogilvyRoleReference,
+  // companyLogoSrc: wire when DAVID / Ogilvy brand assets are provided (light + dark).
   roleMatchIntro: creativeAgency.alignmentIntro,
   roleMatchRows: [
     {
-      requirement: 'Editorial judgment with AI production',
+      requirement: 'Lead AI production workflows & set the standard',
       evidence:
         'AI24 editorial pipeline with human review before publish; Lore Machine prompt systems turning narrative into structured multimedia under craft control.',
       status: 'demonstrated',
       illustration: { src: ai24.imageSrc, alt: ai24.imageAlt },
     },
     {
-      requirement: 'Visual and conceptual craft',
+      requirement: 'Own concept → script → execution with AI',
       evidence:
-        'Museum-legible art practice plus product and editorial visual systems—original POV with production finish.',
+        'End-to-end creative systems from brief to channel crops; self-initiated campaign study shows exploration → critique → Ready specimens.',
       status: 'demonstrated',
       illustration: { src: lore.imageSrc, alt: lore.imageAlt },
     },
     {
-      requirement: 'Enablement and critique culture',
+      requirement: 'Platform-native social & audiovisual storytelling',
+      evidence:
+        'All Studios Everything (18M+ YouTube views) plus multi-format campaign adaptations—hooks, pacing, and channel-aware crops.',
+      status: 'demonstrated',
+      illustration: { src: ALL_STUDIOS_POSTER, alt: 'All Studios Everything — YouTube proof' },
+    },
+    {
+      requirement: 'Adobe craft + AI creative tools fluency',
+      evidence:
+        'Expert Adobe finishing (Photoshop, Illustrator, InDesign, Premiere, After Effects) with generative exploration under review—Firefly, Google AI / VEO-class, OpenAI, and ComfyUI workflows as accelerators.',
+      status: 'demonstrated',
+      illustration: { src: multimodal.imageSrc, alt: multimodal.imageAlt },
+    },
+    {
+      requirement: 'Mentor creators & cross-functional collaboration',
       evidence:
         'Oolite workshops and artist mentorship; translating emerging tools for non-engineers; review gates as pedagogy.',
       status: 'demonstrated',
       illustration: { src: OOLITE_DIGITAL_LAB_IMAGE, alt: OOLITE_DIGITAL_LAB_IMAGE_ALT },
     },
     {
-      requirement: 'Network / agency campaign ownership',
+      requirement: 'Network / DAVID–Ogilvy client campaign ownership',
       evidence:
-        'Not claimed. Conventional agency ACD title path and Ogilvy client campaigns remain an honest gap—addressed via self-initiated channel study (Ready specimens only).',
+        'Not claimed. Conventional agency title path and DAVID/Ogilvy client campaigns remain an honest gap—addressed via self-initiated channel study and viral craft proof (Ready specimens only).',
       status: 'todo',
     },
   ],
-  emailSubject: 'Ogilvy — Creative Editor / AI — Moises Sanabria',
+  processIntro:
+    'How I would operate on DAVID briefs: lock brand constraints, explore under direction, finish in Adobe, adapt for platforms, and mentor creators so speed never outruns taste.',
+  emailSubject: 'DAVID / Ogilvy — Creative Editor / AI — Moises Sanabria',
   availabilityNote:
-    'Available for Ogilvy Creative Editor/AI conversations; Miami-active listing — confirm location and hybrid expectations against the live post.',
+    'Available for DAVID Agency Creative Editor/AI conversations (Ogilvy / WPP · Miami listing posted 08/04/2026). Confirm hybrid / onsite expectations against the live post.',
   applicationStatus: 'ready',
-  careerPacketHref: '/career-packet',
+  careerPacketHref: '/creative-ai',
 });

--- a/src/content/opportunities/systemsDossier.ts
+++ b/src/content/opportunities/systemsDossier.ts
@@ -150,6 +150,8 @@ export type RoleReferenceData = {
   title: string;
   fields: RoleReferenceField[];
   platformReferences: string[];
+  /** Optional narrative blocks (e.g. About DAVID / Ogilvy / WPP) shown when expanded. */
+  narrativeSections?: { heading: string; body: string }[];
   /** Only set when a real careers URL is available. */
   listingUrl?: string;
   listingUrlLabel?: string;

--- a/src/content/opportunities/types.ts
+++ b/src/content/opportunities/types.ts
@@ -1,6 +1,6 @@
 import type { CaseStudyOverride } from '@/content/evidence/caseStudyCards';
 import type { LogoBandItem } from '@/content/evidence/recruitingLogoBand';
-import type { EvidenceStatus, SystemsDossier } from '@/content/opportunities/systemsDossier';
+import type { EvidenceStatus, RoleReferenceData, SystemsDossier } from '@/content/opportunities/systemsDossier';
 import type { RolePortfolioDossier } from '@/content/opportunities/rolePortfolio';
 import type { CreativeAgencyDossier } from '@/content/opportunities/creativeAgencyDossier';
 
@@ -211,6 +211,8 @@ export type Opportunity = {
   };
   /** Systems engineering application sections (architecture, trust, 30/60/90, etc.). */
   systemsDossier?: SystemsDossier;
+  /** Optional expandable JD / listing snapshot (creative-agency + systems). */
+  roleReference?: RoleReferenceData;
   /** Creative / forward-deployed role portfolio sections (no Affirm-shaped architecture panels). */
   rolePortfolio?: RolePortfolioDossier;
   /** Art-direction / creative-director dossier sections (campaign system, AI workflow, POV). */


### PR DESCRIPTION
## Summary
- Ship DAVID/Ogilvy Creative Editor/AI dossier upgrades: YouTube embed (All Studios Everything), expandable About DAVID/Ogilvy/WPP, skills icons + tool logo band, sticky nav, breathing room.
- JD-aligned fit matrix and listing meta (Miami, posted 08/04/2026).

## Test plan
- [ ] `/opportunities/ogilvy-senior-ai-driven-creative-director` loads
- [ ] Expand listing accordion → About DAVID / Ogilvy / WPP visible
- [ ] Motion section embeds YouTube `XuSwUBULiQs`
- [ ] Skills icons + logo band render
- [ ] Sticky nav jumps to skills / motion / process
- [ ] CTA packet links to `/creative-ai`


Made with [Cursor](https://cursor.com)