### PR TITLE
Polish creative dossiers: accordions, sheen, interactive stack

### DIFF
--- a/src/components/opportunities/CapabilityMap.tsx
+++ b/src/components/opportunities/CapabilityMap.tsx
@@ -1,5 +1,9 @@
+'use client';
+
+import { useState } from 'react';
 import { opp } from '@/components/opportunities/opportunityTheme';
 import { OpportunityRichText } from '@/components/opportunities/OpportunityRichText';
+import { resolveTechLogos } from '@/content/evidence/tech-logos';
 import type { CapabilityMapData } from '@/content/opportunities/systemsDossier';
 import { getOpportunityCompactAccent } from '@/config/opportunity-compact-section-theme';
 import { cn } from '@/lib/utils';
@@ -12,6 +16,9 @@ type CapabilityMapProps = {
 
 export function CapabilityMap({ data, sectionId = 'capabilities', className }: CapabilityMapProps) {
   const accent = getOpportunityCompactAccent(sectionId);
+  const [activeId, setActiveId] = useState(data.groups[0]?.id ?? '');
+  const activeGroup = data.groups.find((g) => g.id === activeId) ?? data.groups[0];
+  const activeLogos = resolveTechLogos(activeGroup?.logoIds ?? []);
 
   return (
     <section
@@ -27,32 +34,129 @@ export function CapabilityMap({ data, sectionId = 'capabilities', className }: C
       </h2>
       {data.subtitle ? <p className={`mt-2 max-w-3xl ${opp.muted}`}>{data.subtitle}</p> : null}
 
-      <div className="mt-8 grid gap-3 sm:grid-cols-2 sm:gap-4">
-        {data.groups.map((group) => (
-          <div key={group.id} className={cn(opp.card, 'border-l-[3px] p-4 sm:p-5', accent.rail, accent.softBg)}>
-            <h3 className={opp.h3MoMA}>{group.title}</h3>
-            {group.items.length === 1 ? (
-              <p className={`mt-3 ${opp.body}`}>
-                <OpportunityRichText text={group.items[0]} />
-              </p>
-            ) : (
-              <ul className="mt-3 space-y-1.5">
-                {group.items.map((item) => (
-                  <li key={item.slice(0, 48)} className={opp.body}>
-                    <span className="mr-2 text-stone-400" aria-hidden>
-                      ·
+      <div className="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:items-start lg:gap-8">
+        <ul className="grid gap-3 sm:grid-cols-2 sm:gap-3 lg:grid-cols-1">
+          {data.groups.map((group, index) => {
+            const active = group.id === activeGroup?.id;
+            return (
+              <li key={group.id}>
+                <button
+                  type="button"
+                  className={cn(
+                    'w-full rounded-2xl border p-4 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-500 sm:p-5',
+                    active
+                      ? cn(
+                          'border-stone-300 bg-white shadow-sm ring-1 ring-stone-200/80 dark:border-stone-600 dark:bg-stone-900 dark:ring-stone-700/80',
+                          accent.softBg,
+                        )
+                      : 'border-stone-200/80 bg-white/70 hover:border-stone-300 hover:bg-white dark:border-stone-700/80 dark:bg-stone-950/40 dark:hover:border-stone-600 dark:hover:bg-stone-900',
+                  )}
+                  onClick={() => setActiveId(group.id)}
+                  onMouseEnter={() => setActiveId(group.id)}
+                  aria-pressed={active}
+                >
+                  <div className="flex items-start gap-3">
+                    <span
+                      className={cn(
+                        'mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-bold tabular-nums',
+                        accent.navIdle,
+                        accent.eyebrow,
+                      )}
+                    >
+                      {String(index + 1).padStart(2, '0')}
                     </span>
-                    <OpportunityRichText text={item} />
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        ))}
+                    <div className="min-w-0">
+                      <h3 className={opp.h3MoMA}>{group.title}</h3>
+                      <p className={cn(opp.subtle, 'mt-1 line-clamp-2')}>
+                        {group.items[0]?.replace(/\*\*/g, '') ?? ''}
+                      </p>
+                      {group.logoIds?.length ? (
+                        <div className="mt-3 flex flex-wrap gap-1.5">
+                          {resolveTechLogos(group.logoIds.slice(0, 4)).map((logo) => (
+                            <span
+                              key={logo.id}
+                              className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-stone-200 bg-white p-1 dark:border-stone-700 dark:bg-stone-800"
+                              title={logo.label}
+                            >
+                              {logo.imageSrc ? (
+                                // eslint-disable-next-line @next/next/no-img-element
+                                <img
+                                  src={logo.imageSrc}
+                                  alt=""
+                                  className={cn('h-full w-full object-contain', logo.imageClassName)}
+                                />
+                              ) : (
+                                <span className="text-[8px] font-bold uppercase text-stone-500">
+                                  {logo.label.slice(0, 3)}
+                                </span>
+                              )}
+                            </span>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+
+        <div
+          className={cn(
+            'rounded-2xl border border-stone-200 bg-white p-5 shadow-sm dark:border-stone-700 dark:bg-stone-900 sm:p-6 lg:sticky lg:top-28',
+            accent.softBg,
+          )}
+        >
+          {activeGroup ? (
+            <>
+              <p className={cn('text-xs font-semibold uppercase tracking-wide', accent.eyebrow)}>
+                Selected stack
+              </p>
+              <h3 className={`mt-2 ${opp.h3MoMA}`}>{activeGroup.title}</h3>
+              {activeLogos.length ? (
+                <ul className="mt-5 flex flex-wrap gap-2">
+                  {activeLogos.map((logo) => (
+                    <li
+                      key={logo.id}
+                      className="inline-flex items-center gap-2 rounded-full border border-stone-200 bg-white px-3 py-1.5 text-xs font-medium text-stone-700 shadow-sm dark:border-stone-700 dark:bg-stone-950 dark:text-stone-200"
+                    >
+                      {logo.imageSrc ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={logo.imageSrc}
+                          alt=""
+                          className={cn('h-4 w-4 object-contain', logo.imageClassName)}
+                        />
+                      ) : null}
+                      {logo.label}
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+              {activeGroup.items.length === 1 ? (
+                <p className={`mt-5 ${opp.body}`}>
+                  <OpportunityRichText text={activeGroup.items[0]} />
+                </p>
+              ) : (
+                <ul className="mt-5 space-y-2">
+                  {activeGroup.items.map((item) => (
+                    <li key={item.slice(0, 48)} className={opp.body}>
+                      <span className="mr-2 text-stone-400" aria-hidden>
+                        ·
+                      </span>
+                      <OpportunityRichText text={item} />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </>
+          ) : null}
+        </div>
       </div>
 
       {data.currentlyExtending?.length ? (
-        <p className={`mt-6 max-w-3xl ${opp.subtle}`}>
+        <p className={`mt-8 max-w-3xl ${opp.subtle}`}>
           <span className="font-semibold text-stone-500 dark:text-stone-400">Currently extending: </span>
           {data.currentlyExtending.join(' · ')}
         </p>

--- a/src/components/opportunities/OpportunityHero.tsx
+++ b/src/components/opportunities/OpportunityHero.tsx
@@ -215,20 +215,47 @@ export function OpportunityHero({ opportunity }: OpportunityHeroProps) {
           {hero.headshotSrc ? (
             <>
               <p className={`mb-2 ${opp.label}`}>Profile</p>
-              <div className={opp.headshot}>
-                {headshotRemote || !hero.headshotSrc.endsWith('.svg') ? (
-                  <Image
-                    src={hero.headshotSrc}
-                    alt={hero.headshotAlt ?? ''}
-                    fill
-                    className="object-cover"
-                    sizes="(max-width: 1024px) 100vw, 400px"
-                    priority
-                  />
-                ) : (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={hero.headshotSrc} alt={hero.headshotAlt ?? ''} className="h-full w-full object-cover" />
+              <div
+                className={cn(
+                  opp.headshot,
+                  'group/portrait relative border-0 bg-transparent [perspective:1200px]',
                 )}
+              >
+                <div
+                  className={cn(
+                    'relative h-full w-full overflow-hidden rounded-xl border border-stone-200 bg-stone-100 shadow-none transition-[transform,box-shadow] duration-500 ease-out motion-safe:transform-gpu motion-safe:will-change-transform dark:border-stone-700 dark:bg-stone-800',
+                    'motion-safe:group-hover/portrait:shadow-[0_22px_48px_-18px_rgba(0,0,0,0.45)] motion-safe:group-hover/portrait:[transform:rotateY(-7deg)_rotateX(5deg)_scale(1.045)]',
+                    '[transform-style:preserve-3d]',
+                  )}
+                >
+                  {headshotRemote || !hero.headshotSrc.endsWith('.svg') ? (
+                    <Image
+                      src={hero.headshotSrc}
+                      alt={hero.headshotAlt ?? ''}
+                      fill
+                      className="object-cover transition duration-500 motion-safe:group-hover/portrait:scale-[1.06]"
+                      sizes="(max-width: 1024px) 100vw, 400px"
+                      priority
+                    />
+                  ) : (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={hero.headshotSrc}
+                      alt={hero.headshotAlt ?? ''}
+                      className="h-full w-full object-cover transition duration-500 motion-safe:group-hover/portrait:scale-[1.06]"
+                    />
+                  )}
+                  <span
+                    className="pointer-events-none absolute inset-0 overflow-hidden opacity-0 transition-opacity duration-300 motion-safe:group-hover/portrait:opacity-100"
+                    aria-hidden
+                  >
+                    <span className="grant-portrait-sheen absolute inset-y-0 -left-1/2 w-1/2 bg-gradient-to-r from-transparent via-white/45 to-transparent motion-safe:group-hover/portrait:animate-[grant-portrait-sheen_0.85s_ease-in-out]" />
+                  </span>
+                  <span
+                    className="pointer-events-none absolute inset-0 bg-gradient-to-tr from-stone-900/10 via-transparent to-white/10 opacity-0 transition-opacity duration-500 motion-safe:group-hover/portrait:opacity-100"
+                    aria-hidden
+                  />
+                </div>
               </div>
             </>
           ) : null}

--- a/src/components/opportunities/creative-agency/CreativeAgencyClient.tsx
+++ b/src/components/opportunities/creative-agency/CreativeAgencyClient.tsx
@@ -20,6 +20,7 @@ import { LeadershipInPractice } from '@/components/opportunities/creative-agency
 import { PointOfViewGallery } from '@/components/opportunities/creative-agency/PointOfViewGallery';
 import { MotionAndAnimationSection } from '@/components/opportunities/creative-agency/MotionAndAnimationSection';
 import { DossierSectionNav } from '@/components/opportunities/creative-agency/DossierSectionNav';
+import { DossierSectionBreak } from '@/components/opportunities/creative-agency/DossierSectionBreak';
 import { CapabilitiesDeepLink } from '@/components/capabilities/CapabilitiesDeepLink';
 import { getOpportunityCompactAccent } from '@/config/opportunity-compact-section-theme';
 import { opp } from '@/components/opportunities/opportunityTheme';
@@ -51,7 +52,7 @@ export function CreativeAgencyClient({ opportunity }: CreativeAgencyClientProps)
     );
   }
 
-  const sectionClass = 'mt-12 sm:mt-14 md:mt-20';
+  const sectionClass = 'mt-16 sm:mt-20 md:mt-24';
   const framed = '!mt-0 !border-0 !pt-0 scroll-mt-28 sm:scroll-mt-32';
 
   return (
@@ -92,13 +93,13 @@ export function CreativeAgencyClient({ opportunity }: CreativeAgencyClientProps)
         </OpportunityColorSection>
 
         {opportunity.roleReference ? (
-          <div className="mt-8 sm:mt-10">
+          <div className="mt-10 sm:mt-12">
             <RoleReferenceAccordion data={opportunity.roleReference} />
           </div>
         ) : null}
 
         {opportunity.navItems?.length ? (
-          <div className="mt-8 sm:mt-10">
+          <div className="mt-10 sm:mt-12">
             <DossierSectionNav
               items={opportunity.navItems.filter((item) => item.id !== 'hero')}
               title="Dossier map"
@@ -106,6 +107,8 @@ export function CreativeAgencyClient({ opportunity }: CreativeAgencyClientProps)
             />
           </div>
         ) : null}
+
+        <DossierSectionBreak className="mt-10 sm:mt-12" />
 
         <OpportunityColorSection sectionId="capabilities" className={sectionClass}>
           <FitPillars
@@ -118,11 +121,15 @@ export function CreativeAgencyClient({ opportunity }: CreativeAgencyClientProps)
         </OpportunityColorSection>
 
         {hasSkills ? (
-          <OpportunityColorSection sectionId="skills" className={sectionClass}>
-            <SkillsMatrix opportunity={opportunity} framed />
-          </OpportunityColorSection>
+          <>
+            <DossierSectionBreak />
+            <OpportunityColorSection sectionId="skills" className={sectionClass}>
+              <SkillsMatrix opportunity={opportunity} framed />
+            </OpportunityColorSection>
+          </>
         ) : null}
 
+        <DossierSectionBreak />
         <OpportunityColorSection sectionId="case-studies" className={sectionClass}>
           <CreativeCaseStudyModules
             title={agency.caseStudiesTitle}
@@ -133,30 +140,44 @@ export function CreativeAgencyClient({ opportunity }: CreativeAgencyClientProps)
           />
         </OpportunityColorSection>
 
+        <DossierSectionBreak />
         <OpportunityColorSection sectionId="campaign" className={sectionClass}>
           <CampaignChannelSystem data={agency.campaign} sectionId="campaign" className={framed} />
         </OpportunityColorSection>
 
+        <DossierSectionBreak />
         <OpportunityColorSection sectionId="workflow" className={sectionClass}>
           <HumanAiWorkflow data={agency.workflow} sectionId="workflow" className={framed} />
         </OpportunityColorSection>
 
         {agency.motionSection ? (
-          <OpportunityColorSection sectionId="motion" className={sectionClass}>
-            <MotionAndAnimationSection
-              data={agency.motionSection}
-              sectionId="motion"
-              className={framed}
-            />
-          </OpportunityColorSection>
+          <>
+            <DossierSectionBreak />
+            <OpportunityColorSection sectionId="motion" className={sectionClass}>
+              <MotionAndAnimationSection
+                data={agency.motionSection}
+                sectionId="motion"
+                className={framed}
+              />
+            </OpportunityColorSection>
+          </>
         ) : null}
 
         {hasProcess ? (
-          <OpportunityColorSection sectionId="process" className={sectionClass}>
-            <InnovationProcess opportunity={opportunity} sectionId="process" framed layout="horizontal" />
-          </OpportunityColorSection>
+          <>
+            <DossierSectionBreak />
+            <OpportunityColorSection sectionId="process" className={sectionClass}>
+              <InnovationProcess
+                opportunity={opportunity}
+                sectionId="process"
+                framed
+                layout="horizontal"
+              />
+            </OpportunityColorSection>
+          </>
         ) : null}
 
+        <DossierSectionBreak />
         <OpportunityColorSection sectionId="leadership" className={sectionClass}>
           <LeadershipInPractice
             data={agency.leadership}
@@ -165,14 +186,17 @@ export function CreativeAgencyClient({ opportunity }: CreativeAgencyClientProps)
           />
         </OpportunityColorSection>
 
+        <DossierSectionBreak />
         <OpportunityColorSection sectionId="pov" className={sectionClass}>
           <PointOfViewGallery data={agency.pointOfView} sectionId="pov" className={framed} />
         </OpportunityColorSection>
 
+        <DossierSectionBreak />
         <OpportunityColorSection sectionId="fit" className={sectionClass}>
           <RoleMatchMatrix opportunity={opportunity} framed />
         </OpportunityColorSection>
 
+        <DossierSectionBreak />
         <OpportunityColorSection sectionId="stack" className={sectionClass}>
           <CapabilityMap data={dossier.capabilityMap} sectionId="stack" className={framed} />
           {opportunity.capabilitiesHref ? (
@@ -180,7 +204,8 @@ export function CreativeAgencyClient({ opportunity }: CreativeAgencyClientProps)
           ) : null}
         </OpportunityColorSection>
 
-        <OpportunityColorSection sectionId="contact" className={sectionClass}>
+        <DossierSectionBreak />
+        <OpportunityColorSection sectionId="contact" className={cn(sectionClass, 'mb-10 sm:mb-14')}>
           <ResumeCTA opportunity={opportunity} framed sectionId="contact" />
           <p className={`mt-4 max-w-3xl ${opp.subtle}`}>{dossier.availabilityNote}</p>
         </OpportunityColorSection>

--- a/src/components/opportunities/creative-agency/CreativeCaseStudyModules.tsx
+++ b/src/components/opportunities/creative-agency/CreativeCaseStudyModules.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { useId, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { ExternalLink } from 'lucide-react';
+import { ChevronDown, ExternalLink } from 'lucide-react';
 import { OpportunityCardImage } from '@/components/opportunities/OpportunityCardImage';
 import { scrollToDossierSection } from '@/components/opportunities/creative-agency/scrollToDossierSection';
 import { opp } from '@/components/opportunities/opportunityTheme';
@@ -50,6 +51,8 @@ export function CreativeCaseStudyModules({
   className,
 }: CreativeCaseStudyModulesProps) {
   const accent = getOpportunityCompactAccent(sectionId);
+  const baseId = useId();
+  const [openId, setOpenId] = useState<string | null>(studies[0]?.id ?? null);
 
   return (
     <section
@@ -70,162 +73,212 @@ export function CreativeCaseStudyModules({
           Jump to a case study
         </p>
         <ol className="mt-2 flex snap-x snap-mandatory gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] sm:flex-wrap sm:overflow-visible [&::-webkit-scrollbar]:hidden">
-          {studies.map((study, index) => (
-            <li key={study.id} className="shrink-0 snap-start">
-              <a
-                href={`#${study.id}`}
-                className={cn(
-                  'inline-flex min-h-11 items-center gap-1.5 rounded-full border px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-500',
-                  accent.navIdle,
-                  'bg-white dark:bg-stone-900',
-                  accent.eyebrow,
-                )}
-                onClick={(e) => {
-                  e.preventDefault();
-                  scrollToDossierSection(study.id);
-                }}
-              >
-                <span className="tabular-nums opacity-70">{String(index + 1).padStart(2, '0')}</span>
-                {study.title.split(' — ')[0] ?? study.title}
-              </a>
-            </li>
-          ))}
+          {studies.map((study, index) => {
+            const active = openId === study.id;
+            return (
+              <li key={study.id} className="shrink-0 snap-start">
+                <a
+                  href={`#${study.id}`}
+                  className={cn(
+                    'inline-flex min-h-11 items-center gap-1.5 rounded-full border px-3 py-2 text-sm font-medium transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-500',
+                    active
+                      ? cn(accent.navActive, accent.navActiveText)
+                      : cn(accent.navIdle, accent.eyebrow, 'bg-white dark:bg-stone-900'),
+                  )}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    setOpenId(study.id);
+                    scrollToDossierSection(study.id);
+                  }}
+                >
+                  <span className="tabular-nums opacity-70">{String(index + 1).padStart(2, '0')}</span>
+                  {study.title.split(' — ')[0] ?? study.title}
+                </a>
+              </li>
+            );
+          })}
         </ol>
       </nav>
 
-      <div className="mt-10 space-y-10 sm:space-y-14">
-        {studies.map((study) => (
-          <article key={study.id} className="scroll-mt-32" id={study.id}>
-            <div className={cn(opp.card, 'overflow-hidden border-l-[3px]', accent.rail)}>
-              <div className="relative aspect-[16/10] w-full bg-stone-100 dark:bg-stone-800 sm:aspect-[16/9] md:aspect-[2/1]">
-                <CaseMedia src={study.imageSrc} alt={study.imageAlt} local={study.imageLocal} />
-              </div>
-              <div className="p-4 sm:p-6 md:p-7">
-                <div className="flex flex-wrap items-center gap-2">
-                  <p className={cn('text-xs font-medium uppercase tracking-wide', accent.eyebrow)}>
-                    {study.category}
-                  </p>
-                  <span className={opp.pill}>{DELIVERY_STATUS_LABELS[study.deliveryStatus]}</span>
-                </div>
-                <h3 className={`mt-2 ${opp.h3MoMA}`}>{study.title}</h3>
-
-                <dl className="mt-5 grid gap-4 sm:grid-cols-2">
-                  <div className="sm:col-span-2">
-                    <dt className={opp.label}>Context</dt>
-                    <dd className={`mt-1 ${opp.body}`}>{study.context}</dd>
+      <div className="mt-10 space-y-5 sm:space-y-6">
+        {studies.map((study, index) => {
+          const open = openId === study.id;
+          const panelId = `${baseId}-panel-${study.id}`;
+          return (
+            <article
+              key={study.id}
+              className="scroll-mt-32"
+              id={study.id}
+            >
+              <div
+                className={cn(
+                  opp.card,
+                  'overflow-hidden border-l-[3px] transition',
+                  accent.rail,
+                  open ? 'shadow-md ring-1 ring-stone-200/80 dark:ring-stone-700/80' : 'hover:shadow-md',
+                )}
+              >
+                <button
+                  type="button"
+                  aria-expanded={open}
+                  aria-controls={panelId}
+                  className="grid w-full grid-cols-1 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-500 sm:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]"
+                  onClick={() => setOpenId(open ? null : study.id)}
+                >
+                  <div className="relative aspect-[16/10] w-full bg-stone-100 dark:bg-stone-800 sm:aspect-auto sm:min-h-[180px]">
+                    <CaseMedia src={study.imageSrc} alt={study.imageAlt} local={study.imageLocal} />
                   </div>
-                  <div>
-                    <dt className={opp.label}>Challenge</dt>
-                    <dd className={`mt-1 ${opp.body}`}>{study.challenge}</dd>
-                  </div>
-                  <div>
-                    <dt className={opp.label}>Moises’s role</dt>
-                    <dd className={`mt-1 ${opp.body}`}>{study.role}</dd>
-                  </div>
-                  <div className="sm:col-span-2">
-                    <dt className={opp.label}>Design decisions</dt>
-                    <dd className="mt-1">
-                      <ul className={`list-disc space-y-1.5 pl-5 ${opp.body}`}>
-                        {study.designDecisions.map((item) => (
-                          <li key={item.slice(0, 48)}>{item}</li>
-                        ))}
-                      </ul>
-                    </dd>
-                  </div>
-                  <div className="sm:col-span-2">
-                    <dt className={opp.label}>AI or technical workflow</dt>
-                    <dd className={`mt-1 ${opp.body}`}>{study.workflow}</dd>
-                  </div>
-                  <div>
-                    <dt className={opp.label}>Outputs</dt>
-                    <dd className="mt-1">
-                      <ul className={`list-disc space-y-1 pl-5 ${opp.body}`}>
-                        {study.outputs.map((item) => (
-                          <li key={item.slice(0, 40)}>{item}</li>
-                        ))}
-                      </ul>
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className={opp.label}>What changed or was learned</dt>
-                    <dd className={`mt-1 ${opp.body}`}>{study.learning}</dd>
-                  </div>
-                </dl>
-
-                {study.todos?.length ? (
-                  <div className="mt-5 rounded-lg border border-amber-300/60 bg-amber-50/80 p-4 dark:border-amber-700/50 dark:bg-amber-950/30">
-                    <p className="text-[10px] font-semibold uppercase tracking-wide text-amber-900 dark:text-amber-100">
-                      Assets & facts needed
-                    </p>
-                    <ul className="mt-2 space-y-1.5">
-                      {study.todos.map((todo) => (
-                        <li
-                          key={todo}
-                          className="text-xs leading-relaxed text-amber-950 dark:text-amber-100"
-                        >
-                          {todo}
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ) : null}
-
-                {study.gallery?.length ? (
-                  <div className="mt-6 grid gap-3 sm:grid-cols-3">
-                    {study.gallery.map((item) => (
-                      <figure
-                        key={`${item.src}-${item.alt}`}
-                        className="overflow-hidden rounded-lg border border-stone-200 dark:border-stone-700"
-                      >
-                        <div className="relative aspect-[4/3] bg-stone-100 dark:bg-stone-800">
-                          {item.placeholderNote ? (
-                            <div className="flex h-full flex-col items-center justify-center gap-1.5 p-3 text-center">
-                              <span className="rounded-full border border-amber-400/60 bg-amber-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-900 dark:border-amber-600/50 dark:bg-amber-950/50 dark:text-amber-100">
-                                Placeholder
-                              </span>
-                              <span className="text-xs text-stone-500 dark:text-stone-400">
-                                {item.placeholderNote}
-                              </span>
-                            </div>
-                          ) : (
-                            <CaseMedia src={item.src} alt={item.alt} local={item.local} />
-                          )}
-                        </div>
-                        {item.caption ? (
-                          <figcaption
-                            className={`border-t border-stone-100 px-2 py-1.5 dark:border-stone-800 ${opp.subtle}`}
-                          >
-                            {item.caption}
-                          </figcaption>
-                        ) : null}
-                      </figure>
-                    ))}
-                  </div>
-                ) : null}
-
-                {study.href ? (
-                  <div className="mt-5">
-                    <Link
-                      href={study.href}
+                  <div className="flex items-start gap-3 p-4 sm:p-5 md:p-6">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-mono text-[10px] tabular-nums text-stone-400">
+                          {String(index + 1).padStart(2, '0')}
+                        </span>
+                        <p className={cn('text-xs font-medium uppercase tracking-wide', accent.eyebrow)}>
+                          {study.category}
+                        </p>
+                        <span className={opp.pill}>{DELIVERY_STATUS_LABELS[study.deliveryStatus]}</span>
+                      </div>
+                      <h3 className={`mt-2 ${opp.h3MoMA}`}>{study.title}</h3>
+                      <p className={cn(opp.body, 'mt-2 line-clamp-2 text-sm')}>{study.context}</p>
+                      <p className={cn(opp.subtle, 'mt-3 text-xs')}>
+                        {open ? 'Hide details' : 'Read full case'}
+                      </p>
+                    </div>
+                    <ChevronDown
                       className={cn(
-                        opp.linkAccent,
-                        'inline-flex min-h-11 items-center gap-1 text-sm sm:min-h-0',
+                        'mt-1 h-4 w-4 shrink-0 text-stone-400 transition motion-reduce:transition-none',
+                        open && 'rotate-180',
                       )}
-                      {...(study.href.startsWith('http')
-                        ? { target: '_blank', rel: 'noopener noreferrer' }
-                        : {})}
-                    >
-                      {study.linkLabel ?? 'View project'}
-                      {study.href.startsWith('http') ? (
-                        <ExternalLink className="h-3.5 w-3.5" aria-hidden />
-                      ) : null}
-                    </Link>
+                      aria-hidden
+                    />
+                  </div>
+                </button>
+
+                {open ? (
+                  <div
+                    id={panelId}
+                    className="border-t border-stone-100 p-4 dark:border-stone-800 sm:p-6 md:p-7"
+                  >
+                    <dl className="grid gap-4 sm:grid-cols-2">
+                      <div className="sm:col-span-2">
+                        <dt className={opp.label}>Context</dt>
+                        <dd className={`mt-1 ${opp.body}`}>{study.context}</dd>
+                      </div>
+                      <div>
+                        <dt className={opp.label}>Challenge</dt>
+                        <dd className={`mt-1 ${opp.body}`}>{study.challenge}</dd>
+                      </div>
+                      <div>
+                        <dt className={opp.label}>Moises’s role</dt>
+                        <dd className={`mt-1 ${opp.body}`}>{study.role}</dd>
+                      </div>
+                      <div className="sm:col-span-2">
+                        <dt className={opp.label}>Design decisions</dt>
+                        <dd className="mt-1">
+                          <ul className={`list-disc space-y-1.5 pl-5 ${opp.body}`}>
+                            {study.designDecisions.map((item) => (
+                              <li key={item.slice(0, 48)}>{item}</li>
+                            ))}
+                          </ul>
+                        </dd>
+                      </div>
+                      <div className="sm:col-span-2">
+                        <dt className={opp.label}>AI or technical workflow</dt>
+                        <dd className={`mt-1 ${opp.body}`}>{study.workflow}</dd>
+                      </div>
+                      <div>
+                        <dt className={opp.label}>Outputs</dt>
+                        <dd className="mt-1">
+                          <ul className={`list-disc space-y-1 pl-5 ${opp.body}`}>
+                            {study.outputs.map((item) => (
+                              <li key={item.slice(0, 40)}>{item}</li>
+                            ))}
+                          </ul>
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className={opp.label}>What changed or was learned</dt>
+                        <dd className={`mt-1 ${opp.body}`}>{study.learning}</dd>
+                      </div>
+                    </dl>
+
+                    {study.todos?.length ? (
+                      <div className="mt-5 rounded-lg border border-amber-300/60 bg-amber-50/80 p-4 dark:border-amber-700/50 dark:bg-amber-950/30">
+                        <p className="text-[10px] font-semibold uppercase tracking-wide text-amber-900 dark:text-amber-100">
+                          Assets & facts needed
+                        </p>
+                        <ul className="mt-2 space-y-1.5">
+                          {study.todos.map((todo) => (
+                            <li
+                              key={todo}
+                              className="text-xs leading-relaxed text-amber-950 dark:text-amber-100"
+                            >
+                              {todo}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+
+                    {study.gallery?.length ? (
+                      <div className="mt-6 grid gap-3 sm:grid-cols-3">
+                        {study.gallery.map((item) => (
+                          <figure
+                            key={`${item.src}-${item.alt}`}
+                            className="overflow-hidden rounded-lg border border-stone-200 dark:border-stone-700"
+                          >
+                            <div className="relative aspect-[4/3] bg-stone-100 dark:bg-stone-800">
+                              {item.placeholderNote ? (
+                                <div className="flex h-full flex-col items-center justify-center gap-1.5 p-3 text-center">
+                                  <span className="rounded-full border border-amber-400/60 bg-amber-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-900 dark:border-amber-600/50 dark:bg-amber-950/50 dark:text-amber-100">
+                                    Placeholder
+                                  </span>
+                                  <span className="text-xs text-stone-500 dark:text-stone-400">
+                                    {item.placeholderNote}
+                                  </span>
+                                </div>
+                              ) : (
+                                <CaseMedia src={item.src} alt={item.alt} local={item.local} />
+                              )}
+                            </div>
+                            {item.caption ? (
+                              <figcaption
+                                className={`border-t border-stone-100 px-2 py-1.5 dark:border-stone-800 ${opp.subtle}`}
+                              >
+                                {item.caption}
+                              </figcaption>
+                            ) : null}
+                          </figure>
+                        ))}
+                      </div>
+                    ) : null}
+
+                    {study.href ? (
+                      <div className="mt-5">
+                        <Link
+                          href={study.href}
+                          className={cn(
+                            opp.linkAccent,
+                            'inline-flex min-h-11 items-center gap-1 text-sm sm:min-h-0',
+                          )}
+                          {...(study.href.startsWith('http')
+                            ? { target: '_blank', rel: 'noopener noreferrer' }
+                            : {})}
+                        >
+                          {study.linkLabel ?? 'View project'}
+                          {study.href.startsWith('http') ? (
+                            <ExternalLink className="h-3.5 w-3.5" aria-hidden />
+                          ) : null}
+                        </Link>
+                      </div>
+                    ) : null}
                   </div>
                 ) : null}
               </div>
-            </div>
-          </article>
-        ))}
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/src/components/opportunities/creative-agency/DossierSectionBreak.tsx
+++ b/src/components/opportunities/creative-agency/DossierSectionBreak.tsx
@@ -1,0 +1,19 @@
+import { cn } from '@/lib/utils';
+
+type DossierSectionBreakProps = {
+  className?: string;
+};
+
+/** Soft hairline spacer between dossier sections (Apple-like breathing room). */
+export function DossierSectionBreak({ className }: DossierSectionBreakProps) {
+  return (
+    <div
+      className={cn('mx-auto flex w-full max-w-2xl items-center gap-3 px-2 py-2 sm:py-3', className)}
+      aria-hidden
+    >
+      <div className="h-px flex-1 bg-gradient-to-r from-transparent via-stone-200/90 to-transparent dark:via-stone-700/80" />
+      <span className="h-1 w-1 shrink-0 rounded-full bg-stone-300/80 dark:bg-stone-600" />
+      <div className="h-px flex-1 bg-gradient-to-r from-transparent via-stone-200/90 to-transparent dark:via-stone-700/80" />
+    </div>
+  );
+}

--- a/src/components/opportunities/creative-agency/LeadershipInPractice.tsx
+++ b/src/components/opportunities/creative-agency/LeadershipInPractice.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { useId, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
 import { opp } from '@/components/opportunities/opportunityTheme';
 import type { LeadershipBlock } from '@/content/opportunities/creativeAgencyDossier';
 import { getOpportunityCompactAccent } from '@/config/opportunity-compact-section-theme';
@@ -15,6 +19,8 @@ export function LeadershipInPractice({
   className,
 }: LeadershipInPracticeProps) {
   const accent = getOpportunityCompactAccent(sectionId);
+  const baseId = useId();
+  const [openId, setOpenId] = useState<string | null>(data.points[0]?.id ?? null);
 
   return (
     <section
@@ -29,34 +35,62 @@ export function LeadershipInPractice({
         {data.title}
       </h2>
       <p className={`mt-2 max-w-3xl ${opp.muted}`}>{data.intro}</p>
-      <ul className="mt-8 grid gap-3 sm:grid-cols-2 sm:gap-4">
-        {data.points.map((point, index) => (
-          <li
-            key={point.id}
-            className={cn(
-              opp.card,
-              'border-l-[3px] p-4 transition hover:shadow-md sm:p-5',
-              accent.rail,
-              accent.softBg,
-            )}
-          >
-            <div className="flex items-start gap-3">
-              <span
-                className={cn(
-                  'mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-bold tabular-nums',
-                  accent.navIdle,
-                  accent.eyebrow,
-                )}
+      <ul className="mt-8 space-y-3">
+        {data.points.map((point, index) => {
+          const open = openId === point.id;
+          const panelId = `${baseId}-${point.id}`;
+          return (
+            <li
+              key={point.id}
+              className={cn(
+                opp.card,
+                'overflow-hidden border-l-[3px] transition',
+                accent.rail,
+                open ? accent.softBg : 'hover:shadow-md',
+                open && 'shadow-sm',
+              )}
+            >
+              <button
+                type="button"
+                aria-expanded={open}
+                aria-controls={panelId}
+                className="flex w-full items-start gap-3 px-4 py-4 text-left sm:px-5 sm:py-5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-500"
+                onClick={() => setOpenId(open ? null : point.id)}
               >
-                {String(index + 1).padStart(2, '0')}
-              </span>
-              <div className="min-w-0">
-                <h3 className={opp.h3MoMA}>{point.title}</h3>
-                <p className={`mt-2 ${opp.body}`}>{point.body}</p>
-              </div>
-            </div>
-          </li>
-        ))}
+                <span
+                  className={cn(
+                    'mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-bold tabular-nums',
+                    accent.navIdle,
+                    accent.eyebrow,
+                  )}
+                >
+                  {String(index + 1).padStart(2, '0')}
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className={cn(opp.h3MoMA, 'block')}>{point.title}</span>
+                  {!open ? (
+                    <span className={cn(opp.subtle, 'mt-1 line-clamp-2 block')}>{point.body}</span>
+                  ) : null}
+                </span>
+                <ChevronDown
+                  className={cn(
+                    'mt-1 h-4 w-4 shrink-0 text-stone-400 transition motion-reduce:transition-none',
+                    open && 'rotate-180 text-stone-600 dark:text-stone-300',
+                  )}
+                  aria-hidden
+                />
+              </button>
+              {open ? (
+                <div
+                  id={panelId}
+                  className="border-t border-stone-100 px-4 pb-5 pt-0 dark:border-stone-800 sm:px-5"
+                >
+                  <p className={cn(opp.body, 'pl-10 pt-4')}>{point.body}</p>
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
       </ul>
     </section>
   );

--- a/src/content/opportunities/creativeAgencyShared.ts
+++ b/src/content/opportunities/creativeAgencyShared.ts
@@ -614,7 +614,7 @@ export function buildCreativeRolePortfolio(availabilityNote: string): RolePortfo
   return {
     capabilityMap: {
       title: 'Production stack',
-      subtitle: 'Tools used to finish work—not a buzzword list.',
+      subtitle: 'Tools used to finish work—not a buzzword list. Hover or tap a group to inspect.',
       groups: [
         {
           id: 'art-direction',
@@ -622,6 +622,7 @@ export function buildCreativeRolePortfolio(availabilityNote: string): RolePortfo
           items: [
             '**Concept development, visual systems, typography, image direction, presentations, digital and print applications**',
           ],
+          logoIds: ['figma', 'canva'],
         },
         {
           id: 'ai-tools',
@@ -629,6 +630,7 @@ export function buildCreativeRolePortfolio(availabilityNote: string): RolePortfo
           items: [
             '**Midjourney, Adobe Firefly, DALL·E, Runway, Stable Diffusion / ComfyUI research, prompt systems, human review gates**',
           ],
+          logoIds: ['openai', 'comfyui', 'stable-diffusion', 'replicate'],
         },
         {
           id: 'adobe',
@@ -636,6 +638,7 @@ export function buildCreativeRolePortfolio(availabilityNote: string): RolePortfo
           items: [
             '**Photoshop, Illustrator, After Effects, Premiere, Creative Cloud compositing and delivery prep**',
           ],
+          logoIds: ['adobe-premiere', 'adobe-after-effects'],
         },
         {
           id: 'ux-web',
@@ -643,6 +646,7 @@ export function buildCreativeRolePortfolio(availabilityNote: string): RolePortfo
           items: [
             '**Figma, responsive design, accessibility, HTML, CSS, JavaScript, React, Next.js, prototyping to production**',
           ],
+          logoIds: ['figma', 'react', 'nextjs', 'typescript'],
         },
         {
           id: 'ops',
@@ -650,6 +654,7 @@ export function buildCreativeRolePortfolio(availabilityNote: string): RolePortfo
           items: [
             '**Briefs, templates, asset governance, review checkpoints, documentation, cross-functional delivery**',
           ],
+          logoIds: ['airtable', 'github', 'n8n'],
         },
       ],
       currentlyExtending: [

--- a/src/content/opportunities/systemsDossier.ts
+++ b/src/content/opportunities/systemsDossier.ts
@@ -116,6 +116,8 @@ export type CapabilityGroup = {
   id: string;
   title: string;
   items: string[];
+  /** Optional tech logo ids from `techLogoRegistry` for interactive stack cards. */
+  logoIds?: string[];
 };
 
 export type CapabilityMapData = {


### PR DESCRIPTION
## Summary
- Case studies + Leadership become expandable accordions with clearer active-state cues
- Opportunity hero headshot reuses grant portrait sheen / 3D hover
- Production stack is interactive with tech logos (hover/tap groups)
- Soft section breakers + more breathing room across creative-agency dossiers

## Test plan
- [ ] Ogilvy dossier: expand/collapse case studies and leadership rows
- [ ] Hover profile photo → sheen sweep
- [ ] Production stack: hover groups updates logo panel
- [ ] Section spacing feels open / Apple-like


Made with [Cursor](https://cursor.com)