### PR TITLE
Ship Hurix and QuickBooks banners and lift the workshop landing

### DIFF
--- a/docs/workshops-catalog.md
+++ b/docs/workshops-catalog.md
@@ -26,6 +26,7 @@ Public teaching catalog sourced from `Workshops-All Data.csv`.
 | vibe-coding-with-net-art | `/workshop/vibe-coding-with-net-art` |
 | organizing-your-digital-studio | `/workshop/organizing-your-digital-studio` |
 | ai-copyright-and-creative-risk | `/workshop/ai-copyright-and-creative-risk` |
+| quickbooks-automation-for-artists | `/workshop/quickbooks-automation-for-artists` |
 | own-your-digital-presence | `/workshop/own-your-digital-presence` (deep program) |
 
 ## Strategy (SEO + outreach)

--- a/docs/workshops/hurix-quickbooks-banner-prompts.md
+++ b/docs/workshops/hurix-quickbooks-banner-prompts.md
@@ -98,7 +98,7 @@ Avoid: Intuit / QuickBooks official logos, green brand splash, purple AI glow, c
 
 **Alt text once live:** `QuickBooks Automation for Artists — studio bookkeeping workshop banner`
 
-**Interim now:** page uses slide 1 as banner with an “interim” caption until you upload the dedicated strip.
+**Live (2026-08-14):** both strips are 2172×724 on Cloudinary — Hurix `jobs/banners/hurix-genai-sme-banner_nlymdc.png`, QuickBooks `jobs/banners/quickbooks-automation-artists-banner_xzffns.png`. Interim caption removed.
 
 ---
 

--- a/src/components/opportunities/OpportunityApplicationAnswers.tsx
+++ b/src/components/opportunities/OpportunityApplicationAnswers.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ClipboardList } from 'lucide-react';
 import type { Opportunity } from '@/content/opportunities/types';
 import { opp } from '@/components/opportunities/opportunityTheme';
 
@@ -15,9 +16,12 @@ export function OpportunityApplicationAnswers({ opportunity, framed = false }: P
 
   return (
     <section id="application-answers" className={framed ? 'scroll-mt-32' : opp.section}>
-      <h2 className={opp.h2}>
-        {applicationAnswersSectionTitle ?? 'Application answers'}
-      </h2>
+      <div className="flex items-center gap-2">
+        <ClipboardList className="h-5 w-5 text-indigo-600 dark:text-indigo-300" aria-hidden />
+        <h2 className={opp.h2}>
+          {applicationAnswersSectionTitle ?? 'Application answers'}
+        </h2>
+      </div>
       {applicationAnswersIntro ? (
         <p className={`mt-3 max-w-3xl ${opp.body}`}>{applicationAnswersIntro}</p>
       ) : null}

--- a/src/components/opportunities/OpportunityPageClient.tsx
+++ b/src/components/opportunities/OpportunityPageClient.tsx
@@ -90,7 +90,9 @@ export function OpportunityPageClient({ opportunity }: OpportunityPageClientProp
             <CaseStudyGrid opportunity={opportunity} framed />
           </OpportunityColorSection>
 
-          <OpportunityTeachingCredentials opportunity={opportunity} />
+          <OpportunityColorSection sectionId="teaching-cred" className="mt-10 sm:mt-14">
+            <OpportunityTeachingCredentials opportunity={opportunity} framed />
+          </OpportunityColorSection>
 
           <OpportunityColorSection sectionId="skills" className="mt-10 sm:mt-14">
             <SkillsMatrix opportunity={opportunity} framed />

--- a/src/components/opportunities/OpportunityTeachingCredentials.tsx
+++ b/src/components/opportunities/OpportunityTeachingCredentials.tsx
@@ -9,9 +9,10 @@ import { opp } from '@/components/opportunities/opportunityTheme';
 
 type Props = {
   opportunity: Opportunity;
+  framed?: boolean;
 };
 
-export function OpportunityTeachingCredentials({ opportunity }: Props) {
+export function OpportunityTeachingCredentials({ opportunity, framed = false }: Props) {
   const { teachingHighlights, certifications, slug } = opportunity;
   if (!teachingHighlights?.length && !certifications?.length) return null;
 
@@ -20,7 +21,7 @@ export function OpportunityTeachingCredentials({ opportunity }: Props) {
   };
 
   return (
-    <section id="teaching-cred" className={opp.section}>
+    <section id="teaching-cred" className={framed ? 'scroll-mt-32' : opp.section}>
       {teachingHighlights?.length ? (
         <div>
           <div className="flex items-center gap-2">

--- a/src/components/workshops/WorkshopCatalogLandingClient.tsx
+++ b/src/components/workshops/WorkshopCatalogLandingClient.tsx
@@ -3,6 +3,18 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import {
+  ArrowRight,
+  ClipboardCheck,
+  Clock,
+  FolderTree,
+  MapPinned,
+  Package,
+  Receipt,
+  Users,
+  Workflow,
+  type LucideIcon,
+} from 'lucide-react';
+import {
   getWorkshopBySlug,
   relatedWorkshops,
   type WorkshopCatalogEntry,
@@ -21,14 +33,17 @@ import {
   INSTITUTIONAL_EMAIL,
 } from '@/content/institutions/shared';
 import {
+  INST_ACCENT,
   InstContainer,
   InstFamilyNav,
   InstPageShell,
   InstPrimaryCta,
+  InstReveal,
   InstSecondaryCta,
   InstSectionLabel,
 } from '@/components/institutions/InstitutionalUi';
 import { track } from '@/lib/analytics';
+import { cn } from '@/lib/utils';
 
 const WORKSHOP_LANDING_MEDIA: Record<
   string,
@@ -36,6 +51,18 @@ const WORKSHOP_LANDING_MEDIA: Record<
 > = {
   'quickbooks-automation-for-artists': QUICKBOOKS_AUTOMATION_SLIDES,
 };
+
+const QUICKBOOKS_AGENDA_ICONS: LucideIcon[] = [
+  MapPinned,
+  FolderTree,
+  Workflow,
+  ClipboardCheck,
+];
+
+const STUDIO_FLOW = ['Invoice', 'Category', 'Review', 'Archive'] as const;
+
+const paperPattern =
+  'bg-[#f7f6f3] bg-[radial-gradient(circle_at_1px_1px,rgb(28_25_23_/_0.06)_1px,transparent_0)] bg-[size:18px_18px]';
 
 export function WorkshopCatalogLandingClient({ slug }: { slug: string }) {
   const workshop = getWorkshopBySlug(slug);
@@ -65,8 +92,8 @@ export function WorkshopCatalogLandingClient({ slug }: { slug: string }) {
       <InstFamilyNav active="workshops" className="sticky top-0 z-40" />
 
       {isQuickBooks ? (
-        <div className="relative w-full overflow-hidden border-b border-neutral-200 bg-neutral-900">
-          <div className="relative mx-auto aspect-[21/9] max-h-[280px] w-full sm:max-h-[320px] lg:max-h-[360px]">
+        <div className="relative w-full overflow-hidden border-b border-neutral-200 bg-[#1c1916]">
+          <div className="relative h-[min(calc(100vw/3),420px)] w-full">
             <Image
               src={QUICKBOOKS_AUTOMATION_BANNER.src}
               alt={QUICKBOOKS_AUTOMATION_BANNER.alt}
@@ -75,7 +102,6 @@ export function WorkshopCatalogLandingClient({ slug }: { slug: string }) {
               className="object-cover object-center"
               sizes="100vw"
             />
-            <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/20 to-transparent" />
           </div>
         </div>
       ) : cover ? (
@@ -94,18 +120,52 @@ export function WorkshopCatalogLandingClient({ slug }: { slug: string }) {
         </div>
       ) : null}
 
-      <header className="border-b border-neutral-200 bg-[#f7f6f3]">
+      <header
+        className={cn(
+          'border-b border-neutral-200',
+          isQuickBooks
+            ? cn(paperPattern, 'bg-gradient-to-br from-amber-50/90 via-[#f7f6f3] to-stone-100')
+            : 'bg-[#f7f6f3]',
+        )}
+      >
         <InstContainer className="py-12 sm:py-16">
-          <InstSectionLabel>Workshop · {workshop.track}</InstSectionLabel>
-          <p className="font-mono text-[11px] tracking-[0.12em] uppercase text-neutral-500 mb-3">
-            {workshop.level} · {workshop.duration} · Ready
-          </p>
+          <InstSectionLabel accent={isQuickBooks ? 'copper' : 'ink'}>
+            Workshop · {workshop.track}
+          </InstSectionLabel>
+          {isQuickBooks ? (
+            <div className="mb-4 inline-flex items-center gap-2">
+              <span className={cn('inline-flex h-8 w-8 items-center justify-center', INST_ACCENT.copper.iconBg)}>
+                <Receipt className="h-4 w-4" aria-hidden />
+              </span>
+              <p className="font-mono text-[11px] tracking-[0.12em] uppercase text-amber-900/80">
+                {workshop.level} · {workshop.duration} · Ready
+              </p>
+            </div>
+          ) : (
+            <p className="font-mono text-[11px] tracking-[0.12em] uppercase text-neutral-500 mb-3">
+              {workshop.level} · {workshop.duration} · Ready
+            </p>
+          )}
           <h1 className="font-['MoMA_Sans'] text-3xl sm:text-5xl font-bold tracking-tight text-neutral-950 max-w-3xl">
             {workshop.publicTitle}
           </h1>
           <p className="mt-4 text-lg sm:text-xl text-neutral-700 max-w-2xl leading-relaxed">
             {workshop.hook}
           </p>
+          {isQuickBooks ? (
+            <ol className="mt-6 flex flex-wrap items-center gap-x-2 gap-y-2" aria-label="Studio money workflow">
+              {STUDIO_FLOW.map((step, i) => (
+                <li key={step} className="inline-flex items-center gap-2">
+                  <span className="border border-amber-200/80 bg-white/80 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.14em] text-amber-950">
+                    {step}
+                  </span>
+                  {i < STUDIO_FLOW.length - 1 ? (
+                    <ArrowRight className="h-3.5 w-3.5 text-amber-700/70" aria-hidden />
+                  ) : null}
+                </li>
+              ))}
+            </ol>
+          ) : null}
           <div className="mt-8 flex flex-wrap gap-3">
             <InstPrimaryCta
               href={INSTITUTIONAL_CALENDLY_URL}
@@ -125,31 +185,32 @@ export function WorkshopCatalogLandingClient({ slug }: { slug: string }) {
       {media.length > 0 ? (
         <section className="border-b border-neutral-200 bg-white">
           <InstContainer className="py-10 sm:py-12">
-            <InstSectionLabel>Workshop materials</InstSectionLabel>
+            <InstSectionLabel accent={isQuickBooks ? 'copper' : 'ink'}>
+              Workshop materials
+            </InstSectionLabel>
             <p className="mt-2 max-w-2xl text-sm text-neutral-600">
               Idea Center / studio-ops slides — human review gates, not accountant cosplay.
             </p>
             <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {media.map((shot) => (
-                <figure
-                  key={shot.src}
-                  className="overflow-hidden border border-neutral-200 bg-[#f7f6f3]"
-                >
-                  <div className="relative aspect-[16/10] bg-neutral-200">
-                    <Image
-                      src={shot.src}
-                      alt={shot.alt}
-                      fill
-                      className="object-cover object-top"
-                      sizes="(max-width: 640px) 100vw, 360px"
-                    />
-                  </div>
-                  {shot.caption ? (
-                    <figcaption className="px-3 py-2.5 text-xs leading-snug text-neutral-600">
-                      {shot.caption}
-                    </figcaption>
-                  ) : null}
-                </figure>
+              {media.map((shot, i) => (
+                <InstReveal key={shot.src} delay={i * 0.06}>
+                  <figure className="group overflow-hidden border border-neutral-200 bg-[#f7f6f3] transition hover:border-amber-400/50 hover:shadow-sm">
+                    <div className="relative aspect-[16/10] bg-neutral-200">
+                      <Image
+                        src={shot.src}
+                        alt={shot.alt}
+                        fill
+                        className="object-cover object-top transition duration-500 group-hover:scale-[1.03]"
+                        sizes="(max-width: 640px) 100vw, 360px"
+                      />
+                    </div>
+                    {shot.caption ? (
+                      <figcaption className="px-3 py-2.5 text-xs leading-snug text-neutral-600">
+                        {shot.caption}
+                      </figcaption>
+                    ) : null}
+                  </figure>
+                </InstReveal>
               ))}
             </div>
           </InstContainer>
@@ -160,18 +221,20 @@ export function WorkshopCatalogLandingClient({ slug }: { slug: string }) {
         <InstContainer className="py-12 sm:py-16 grid gap-10 lg:grid-cols-12">
           <div className="lg:col-span-7 space-y-6">
             <div>
-              <InstSectionLabel>Overview</InstSectionLabel>
+              <InstSectionLabel accent={isQuickBooks ? 'copper' : 'ink'}>Overview</InstSectionLabel>
               <p className="text-neutral-800 leading-relaxed">{workshop.shortDescription}</p>
             </div>
             {workshop.whyNow ? (
               <div>
-                <InstSectionLabel>Why now</InstSectionLabel>
+                <InstSectionLabel accent={isQuickBooks ? 'copper' : 'ink'}>Why now</InstSectionLabel>
                 <p className="text-neutral-800 leading-relaxed">{workshop.whyNow}</p>
               </div>
             ) : null}
             {workshop.learningOutcomes.length > 0 ? (
               <div>
-                <InstSectionLabel>Learning outcomes</InstSectionLabel>
+                <InstSectionLabel accent={isQuickBooks ? 'copper' : 'ink'}>
+                  Learning outcomes
+                </InstSectionLabel>
                 <ul className="space-y-2">
                   {workshop.learningOutcomes.map((o) => (
                     <li key={o} className="flex gap-2 text-neutral-800 text-sm sm:text-base">
@@ -196,7 +259,14 @@ export function WorkshopCatalogLandingClient({ slug }: { slug: string }) {
                 />
               </div>
             ) : null}
-            <div className="border border-neutral-200 bg-[#f7f6f3] p-5 sm:p-6">
+            <div
+              className={cn(
+                'border p-5 sm:p-6',
+                isQuickBooks
+                  ? 'border-amber-200/70 bg-gradient-to-br from-amber-50/80 to-[#f7f6f3]'
+                  : 'border-neutral-200 bg-[#f7f6f3]',
+              )}
+            >
               <p className="font-mono text-[11px] tracking-[0.12em] uppercase text-neutral-500 mb-2">
                 Subtitle
               </p>
@@ -226,29 +296,43 @@ export function WorkshopCatalogLandingClient({ slug }: { slug: string }) {
 
       {isQuickBooks ? (
         <>
-          <section className="border-b border-neutral-200 bg-[#f7f6f3]">
+          <section className={cn('border-b border-neutral-200', paperPattern)}>
             <InstContainer className="py-12 sm:py-16">
-              <InstSectionLabel>Session agenda</InstSectionLabel>
+              <InstSectionLabel accent="copper">Session agenda</InstSectionLabel>
               <h2 className="font-['MoMA_Sans'] text-2xl sm:text-3xl font-bold tracking-tight text-neutral-950 mt-2 mb-8">
                 What we cover
               </h2>
               <ol className="grid gap-4 sm:grid-cols-2">
-                {QUICKBOOKS_AUTOMATION_AGENDA.map((step, i) => (
-                  <li
-                    key={step.title}
-                    className="border border-neutral-200 bg-white p-5 sm:p-6"
-                  >
-                    <p className="font-mono text-[11px] tracking-[0.12em] uppercase text-neutral-500 mb-2">
-                      {String(i + 1).padStart(2, '0')}
-                    </p>
-                    <h3 className="font-['MoMA_Sans'] text-lg font-bold leading-snug">
-                      {step.title}
-                    </h3>
-                    <p className="mt-2 text-sm text-neutral-600 leading-relaxed">
-                      {step.description}
-                    </p>
-                  </li>
-                ))}
+                {QUICKBOOKS_AUTOMATION_AGENDA.map((step, i) => {
+                  const Icon = QUICKBOOKS_AGENDA_ICONS[i] ?? Workflow;
+                  return (
+                    <li key={step.title}>
+                      <InstReveal delay={i * 0.07}>
+                        <div className="group h-full border border-neutral-200 bg-white p-5 sm:p-6 transition hover:-translate-y-0.5 hover:border-amber-400/55 hover:shadow-sm">
+                          <div className="mb-3 flex items-center justify-between gap-3">
+                            <span
+                              className={cn(
+                                'inline-flex h-9 w-9 items-center justify-center',
+                                INST_ACCENT.copper.iconBg,
+                              )}
+                            >
+                              <Icon className="h-4 w-4" aria-hidden />
+                            </span>
+                            <p className="font-mono text-[11px] tracking-[0.12em] uppercase text-amber-800/80">
+                              {String(i + 1).padStart(2, '0')}
+                            </p>
+                          </div>
+                          <h3 className="font-['MoMA_Sans'] text-lg font-bold leading-snug">
+                            {step.title}
+                          </h3>
+                          <p className="mt-2 text-sm text-neutral-600 leading-relaxed">
+                            {step.description}
+                          </p>
+                        </div>
+                      </InstReveal>
+                    </li>
+                  );
+                })}
               </ol>
             </InstContainer>
           </section>
@@ -256,33 +340,37 @@ export function WorkshopCatalogLandingClient({ slug }: { slug: string }) {
           <section className="border-b border-neutral-200 bg-white">
             <InstContainer className="py-12 sm:py-16 grid gap-10 lg:grid-cols-12">
               <div className="lg:col-span-5">
-                <InstSectionLabel>Who it&apos;s for</InstSectionLabel>
+                <InstSectionLabel accent="copper">Who it&apos;s for</InstSectionLabel>
                 <ul className="mt-4 space-y-3">
                   {QUICKBOOKS_AUTOMATION_AUDIENCE.map((item) => (
-                    <li key={item} className="flex gap-2 text-neutral-800 text-sm sm:text-base">
-                      <span className="text-neutral-400 mt-1.5">·</span>
+                    <li key={item} className="flex gap-3 text-neutral-800 text-sm sm:text-base">
+                      <Users className="mt-0.5 h-4 w-4 shrink-0 text-amber-800" aria-hidden />
                       <span>{item}</span>
                     </li>
                   ))}
                 </ul>
               </div>
               <div className="lg:col-span-4">
-                <InstSectionLabel>Formats</InstSectionLabel>
+                <InstSectionLabel accent="teal">Formats</InstSectionLabel>
                 <ul className="mt-4 space-y-4">
                   {QUICKBOOKS_AUTOMATION_FORMATS.map((f) => (
-                    <li key={f.label}>
-                      <p className="font-medium text-neutral-900">{f.label}</p>
-                      <p className="text-sm text-neutral-600 mt-1">{f.detail}</p>
+                    <li key={f.label} className="flex gap-3">
+                      <Clock className="mt-0.5 h-4 w-4 shrink-0 text-teal-800" aria-hidden />
+                      <div>
+                        <p className="font-medium text-neutral-900">{f.label}</p>
+                        <p className="text-sm text-neutral-600 mt-1">{f.detail}</p>
+                      </div>
                     </li>
                   ))}
                 </ul>
               </div>
               <div className="lg:col-span-3">
-                <InstSectionLabel>Leave with</InstSectionLabel>
+                <InstSectionLabel accent="ocean">Leave with</InstSectionLabel>
                 <ul className="mt-4 space-y-2">
                   {QUICKBOOKS_AUTOMATION_DELIVERABLES.map((d) => (
-                    <li key={d} className="text-sm text-neutral-800">
-                      {d}
+                    <li key={d} className="flex gap-2 text-sm text-neutral-800">
+                      <Package className="mt-0.5 h-4 w-4 shrink-0 text-sky-800" aria-hidden />
+                      <span>{d}</span>
                     </li>
                   ))}
                 </ul>
@@ -290,10 +378,14 @@ export function WorkshopCatalogLandingClient({ slug }: { slug: string }) {
             </InstContainer>
           </section>
 
-          <section className="border-b border-neutral-200 bg-[#f7f6f3]">
+          <section
+            className={cn(
+              'border-b border-neutral-200 bg-gradient-to-br from-amber-50 via-[#f7f6f3] to-stone-100',
+            )}
+          >
             <InstContainer className="py-12 sm:py-16 flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
               <div className="max-w-xl">
-                <InstSectionLabel>Next step</InstSectionLabel>
+                <InstSectionLabel accent="copper">Next step</InstSectionLabel>
                 <h2 className="font-['MoMA_Sans'] text-2xl font-bold mt-2">
                   Book for a studio, residency, or Digilab cohort
                 </h2>
@@ -340,7 +432,7 @@ export function WorkshopCatalogLandingClient({ slug }: { slug: string }) {
 
 function RelatedCard({ workshop }: { workshop: WorkshopCatalogEntry }) {
   return (
-    <li className="border border-neutral-200 bg-[#f7f6f3] p-4">
+    <li className="border border-neutral-200 bg-[#f7f6f3] p-4 transition hover:-translate-y-0.5 hover:border-neutral-400 hover:shadow-sm">
       <p className="font-mono text-[10px] uppercase tracking-[0.12em] text-neutral-500 mb-2">
         {workshop.duration}
       </p>

--- a/src/components/workshops/WorkshopCatalogLandingClient.tsx
+++ b/src/components/workshops/WorkshopCatalogLandingClient.tsx
@@ -72,15 +72,10 @@ export function WorkshopCatalogLandingClient({ slug }: { slug: string }) {
               alt={QUICKBOOKS_AUTOMATION_BANNER.alt}
               fill
               priority
-              className="object-cover object-top"
+              className="object-cover object-center"
               sizes="100vw"
             />
             <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/20 to-transparent" />
-            {QUICKBOOKS_AUTOMATION_BANNER.interim ? (
-              <p className="absolute bottom-3 left-4 right-4 font-mono text-[10px] uppercase tracking-[0.14em] text-white/70 sm:left-8">
-                Interim banner · dedicated strip coming
-              </p>
-            ) : null}
           </div>
         </div>
       ) : cover ? (

--- a/src/config/opportunity-compact-section-theme.ts
+++ b/src/config/opportunity-compact-section-theme.ts
@@ -212,6 +212,8 @@ const byId: Record<string, OpportunityCompactSectionAccent> = {
   gan: technologies,
   layers: capabilities,
   overview: hero,
+  'teaching-cred': process,
+  'application-answers': leadership,
   'future-cases': comingSoon,
   related: fit,
   'data-model': process,

--- a/src/constants/workshop-features.ts
+++ b/src/constants/workshop-features.ts
@@ -82,6 +82,18 @@ export const WORKSHOP_FEATURES: WorkshopFeature[] = [
     ctaLabel: 'View overview',
   },
   {
+    title: 'QuickBooks Automation for Artists',
+    description:
+      'Studio bookkeeping made usable — invoices, expenses, and categories with light automation and human review gates.',
+    link: '/workshop/quickbooks-automation-for-artists',
+    disabled: false,
+    instructor: null,
+    instructorRole: null,
+    featured: true,
+    cardVisual: 'generic',
+    ctaLabel: 'Open workshop',
+  },
+  {
     title: 'Learn AI Without Losing Yourself',
     description:
       'Separate live workshop-performance on practical AI, burnout culture, and staying human in the loop—writing, research, and creative work without flattening your voice.',

--- a/src/content/evidence/applicationBanners.ts
+++ b/src/content/evidence/applicationBanners.ts
@@ -44,11 +44,11 @@ export const seniorGenAiEngineerBanner = defineApplicationBanner({
   intrinsicRatio: GENAI_BANNER_RATIO,
 });
 
-/** Role banner for GenAI curriculum / SME education contracts (Hurix and reusable overlays). */
+/** Role banner for GenAI curriculum / SME education contracts (Hurix and reusable overlays). Measured 2172×724. */
 export const genAiCurriculumSmeBanner = defineApplicationBanner({
-  src: `${cdn}/v1778695455/jobs/banners/senior-genai-engineer-banner_iljp58.png`,
-  alt: 'Subject Matter Expert — Generative AI curriculum and technical learning content',
-  intrinsicRatio: GENAI_BANNER_RATIO,
+  src: `${cdn}/v1786719736/jobs/banners/hurix-genai-sme-banner_nlymdc.png`,
+  alt: 'Subject Matter Expert — Generative AI — curriculum, labs, and video-ready teaching banner',
+  intrinsicRatio: CREATIVE_AGENCY_BANNER_RATIO,
 });
 
 export const knightTechProductStrategistBanner = defineApplicationBanner({

--- a/src/content/evidence/applicationBanners.ts
+++ b/src/content/evidence/applicationBanners.ts
@@ -9,6 +9,13 @@ const cdn = 'https://res.cloudinary.com/dck5rzi4h/image/upload';
  */
 export const CREATIVE_AGENCY_BANNER_RATIO = 3;
 
+/**
+ * 3:1 strip height — fills viewport width so 2172×724 assets don't leave a gray band.
+ * Height tracks width, capped at 640px.
+ */
+const FLAGSHIP_BANNER_FRAME =
+  '!h-[min(calc(100vw/3),640px)] sm:!h-[min(calc(100vw/3),640px)] md:!h-[min(calc(100vw/3),640px)] lg:!h-[min(calc(100vw/3),640px)] xl:!h-[min(calc(100vw/3),640px)] w-full';
+
 /** Older gen-AI / strategy banners (CVS, Knight, creative-tech). Measured: 1916×821 → ~2.334. */
 export const GENAI_BANNER_RATIO = 1916 / 821;
 
@@ -49,6 +56,7 @@ export const genAiCurriculumSmeBanner = defineApplicationBanner({
   src: `${cdn}/v1786719736/jobs/banners/hurix-genai-sme-banner_nlymdc.png`,
   alt: 'Subject Matter Expert — Generative AI — curriculum, labs, and video-ready teaching banner',
   intrinsicRatio: CREATIVE_AGENCY_BANNER_RATIO,
+  frameClass: FLAGSHIP_BANNER_FRAME,
 });
 
 export const knightTechProductStrategistBanner = defineApplicationBanner({
@@ -133,14 +141,6 @@ export const ogilvySeniorAiDrivenCreativeDirectorBanner = defineApplicationBanne
   alt: 'Ogilvy — Creative Editor / AI application banner',
   intrinsicRatio: CREATIVE_AGENCY_BANNER_RATIO,
 });
-
-/**
- * Public hiring flagships — measured 2172×724 (~3:1).
- * Height tracks viewport width so the collage spans edge-to-edge (shared opportunity
- * strip is shorter and left a large empty gray band on desktop).
- */
-const FLAGSHIP_BANNER_FRAME =
-  '!h-[min(calc(100vw/3),640px)] sm:!h-[min(calc(100vw/3),640px)] md:!h-[min(calc(100vw/3),640px)] lg:!h-[min(calc(100vw/3),640px)] xl:!h-[min(calc(100vw/3),640px)] w-full';
 
 /** Public hiring flagship — `/creative-ai` (measured 2172×724). */
 export const creativeAiFlagshipBanner = defineApplicationBanner({

--- a/src/content/institutions/artistInfrastructure.ts
+++ b/src/content/institutions/artistInfrastructure.ts
@@ -29,6 +29,7 @@ import {
   SOFTWARE_INTERFACES_CREATOR_TOOL,
 } from './artistInfrastructureMedia';
 import {
+  QUICKBOOKS_AUTOMATION_BANNER,
   QUICKBOOKS_AUTOMATION_COVER,
   QUICKBOOKS_AUTOMATION_WORKSHOP_HREF,
 } from '@/content/workshops/quickbooksAutomation';
@@ -127,7 +128,7 @@ export const artistInfrastructurePage = {
       {
         id: 'idea-center-quickbooks',
         title: 'QuickBooks Automation for Artists',
-        note: 'Three workshop slides attached — studio bookkeeping, automation, and human review gates.',
+        note: 'Dedicated workshop banner plus three slides — studio bookkeeping, automation, and human review gates.',
         status: 'attached' as const,
         icon: 'workflow' as const,
         href: QUICKBOOKS_AUTOMATION_WORKSHOP_HREF,
@@ -235,12 +236,10 @@ export const artistInfrastructurePage = {
         sectionLabel: 'Open workshop',
       },
       {
-        src: QUICKBOOKS_AUTOMATION_COVER.src,
-        alt: QUICKBOOKS_AUTOMATION_COVER.alt,
+        src: QUICKBOOKS_AUTOMATION_BANNER.src,
+        alt: QUICKBOOKS_AUTOMATION_BANNER.alt,
         title: 'QuickBooks Automation for Artists',
-        caption:
-          QUICKBOOKS_AUTOMATION_COVER.caption ??
-          'Studio bookkeeping made legible — light automation with human review gates.',
+        caption: 'Studio bookkeeping made legible — light automation with human review gates.',
         href: QUICKBOOKS_AUTOMATION_WORKSHOP_HREF,
         sectionLabel: 'Open workshop',
       },
@@ -360,8 +359,8 @@ export const artistInfrastructurePage = {
         accent: 'copper' as const,
         icon: 'workflow' as const,
         image: {
-          src: QUICKBOOKS_AUTOMATION_COVER.src,
-          alt: QUICKBOOKS_AUTOMATION_COVER.alt,
+          src: QUICKBOOKS_AUTOMATION_BANNER.src,
+          alt: QUICKBOOKS_AUTOMATION_BANNER.alt,
         },
       },
       {

--- a/src/content/opportunities/hurix-sme-generative-ai.ts
+++ b/src/content/opportunities/hurix-sme-generative-ai.ts
@@ -5,8 +5,7 @@
  * Reusable overlay for GenAI certificate / curriculum SME contracts
  * (Coursera, edX, Udemy, corporate learning refresh engagements).
  *
- * Banner: currently shares GenAI family asset — replace with dedicated
- * curriculum-SME banner when ready (see docs/workshops/hurix-quickbooks-banner-prompts.md).
+ * Banner: dedicated GenAI SME strip (`genAiCurriculumSmeBanner`).
  */
 
 import type { Opportunity } from './types';

--- a/src/content/workshops/catalog-covers.ts
+++ b/src/content/workshops/catalog-covers.ts
@@ -4,7 +4,7 @@
  */
 
 import type { WorkshopCatalogTrack } from './catalog';
-import { QUICKBOOKS_AUTOMATION_COVER } from './quickbooksAutomation';
+import { QUICKBOOKS_AUTOMATION_BANNER } from './quickbooksAutomation';
 import { LANDING_MEDIA_CDN } from './moonlighter-ai-3d-printing/landing-media';
 
 const CDN = 'https://res.cloudinary.com/dck5rzi4h/image/upload';
@@ -153,8 +153,8 @@ export const WORKSHOP_CATALOG_COVERS: Record<string, { src: string; alt: string 
     alt: 'AI and the arts portfolio — sustainable digital practice',
   },
   'quickbooks-automation-for-artists': {
-    src: QUICKBOOKS_AUTOMATION_COVER.src,
-    alt: QUICKBOOKS_AUTOMATION_COVER.alt,
+    src: QUICKBOOKS_AUTOMATION_BANNER.src,
+    alt: QUICKBOOKS_AUTOMATION_BANNER.alt,
   },
 };
 

--- a/src/content/workshops/quickbooksAutomation.ts
+++ b/src/content/workshops/quickbooksAutomation.ts
@@ -29,14 +29,10 @@ export const QUICKBOOKS_AUTOMATION_SLIDES = [
 
 export const QUICKBOOKS_AUTOMATION_COVER = QUICKBOOKS_AUTOMATION_SLIDES[0];
 
-/**
- * Dedicated workshop banner — replace when ChatGPT asset lands.
- * @see docs/workshops/hurix-quickbooks-banner-prompts.md
- */
+/** Dedicated 2172×724 workshop strip. */
 export const QUICKBOOKS_AUTOMATION_BANNER = {
-  src: QUICKBOOKS_AUTOMATION_COVER.src,
-  alt: 'QuickBooks Automation for Artists — workshop banner (interim: slide 1 until dedicated strip ships)',
-  interim: true as const,
+  src: `${CDN}/v1786719735/jobs/banners/quickbooks-automation-artists-banner_xzffns.png`,
+  alt: 'QuickBooks Automation for Artists — studio bookkeeping workshop banner',
 };
 
 export const QUICKBOOKS_AUTOMATION_AGENDA = [


### PR DESCRIPTION
## Summary
- Wire dedicated 2172×724 Cloudinary banners on the Hurix SME dossier and QuickBooks Automation for Artists workshop.
- Fit those 3:1 strips edge-to-edge (no 21:9 crop or dark overlay) and add QuickBooks to the workshops hub as a live featured card.
- Color-code teaching/answers on compact dossiers and lift the QuickBooks landing with copper rails, icons, and light motion.

## Test plan
- [ ] Open `/opportunities/hurix-sme-generative-ai` and confirm the Hurix GenAI SME banner fills the strip without a gray band.
- [ ] Open `/workshop/quickbooks-automation-for-artists` and confirm the dedicated banner, copper coding, agenda icons, and slide grid.
- [ ] Confirm `/workshops` shows QuickBooks as a featured catalog card using the new banner.
- [ ] Confirm Hurix stays unlisted/noindex and the direct URL still opens.


Made with [Cursor](https://cursor.com)