### PR TITLE
Rebuild /institutions as a museum digital-systems services page

### DIFF
--- a/docs/institutions/README.md
+++ b/docs/institutions/README.md
@@ -7,12 +7,19 @@ Museum-legible pages for incubators, cultural partners, and institutional outrea
 
 Use this order when picking a link:
 
-1. **`/artist-infrastructure`** — primary offer (workshops, systems, engagement formats)
-2. **`/oolite-arts`** — Digilab proof / case study (canonical Oolite story)
-3. **`/institutions`** — verified org + case-study directory
-4. **`/bakehouse`** — systems ask (shipped / proposed / ask buckets)
-5. **`/workshops`** — bookable pilots + public catalog (`#catalog`)
-6. **`/artist-sustainability`** — private YoungArts supplement (`noindex`) — not a public outreach door
+**Museum / nonprofit digital systems (e.g. Courtney at ICA):**
+
+1. **`/institutions`** — focused services page (web, Salesforce, automation, livestreaming, labs)
+2. **`/ica-miami`** · **`/oolite-arts`** · **`/bakehouse`** — flagship proof
+3. Calendly — 20-minute conversation
+
+**Artist-facing workshops / incubators:**
+
+1. **`/artist-infrastructure`** — workshops, systems, engagement formats
+2. **`/oolite-arts`** — Digilab proof
+3. **`/workshops`** — bookable pilots + public catalog (`#catalog`)
+
+**Private:** `/artist-sustainability` — YoungArts supplement (`noindex`) — not a public outreach door.
 
 **Named contact audits:** Dimitry Chamy + Sophia (MadArts) — [`docs/outreach/madarts-dimitry-send-audit.md`](../outreach/madarts-dimitry-send-audit.md).  
 Sophia’s research door includes **`/research/the-algorithm-is-outside`**.
@@ -55,8 +62,9 @@ Next phases: layout polish → 360 viewer → video entries in the same registry
 ## Availability and pricing
 
 - **Collaboration offer line:** `INSTITUTIONAL_COLLABORATION_AVAILABILITY` in [`shared.ts`](../../src/content/institutions/shared.ts) (fall 2026 paid guest teaching / curriculum / pilots). Used by `/artist-infrastructure` hero, engagement, and CTA. `INSTITUTIONAL_AVAILABILITY` aliases this.
+- **Services page availability:** `INSTITUTIONAL_SERVICES_AVAILABILITY` — currently available for project-based and fractional work on `/institutions`. Do not reuse the fall 2026 teaching line there.
 - **Oolite contract context:** `OOLITE_CONTRACT_CONTEXT` (Sept 17, 2026) — case-study framing only, not a competing hero availability line.
-- **Pilot pricing** mirrors Digilab public seat rates via `PILOT_PRICING` + [`workshopsOfferings.ts`](../../src/content/institutions/workshopsOfferings.ts) for workshops/hub. Do **not** present `$45` as an institutional teaching fee on `/artist-infrastructure`.
+- **Pilot pricing** mirrors Digilab public seat rates via `PILOT_PRICING` + [`workshopsOfferings.ts`](../../src/content/institutions/workshopsOfferings.ts) for workshops. Do **not** present `$45` or hosted workshop flats on `/institutions`.
 
 ## Key content files
 
@@ -65,6 +73,7 @@ Next phases: layout polish → 360 viewer → video entries in the same registry
 | `/artist-infrastructure` | `artistInfrastructure.ts` | `ArtistInfrastructureClient.tsx` |
 | `/oolite-arts` | `oolite-arts/case-study.ts` | `OoliteCaseStudy.tsx` |
 | `/institutions` | `hub.ts` | `InstitutionsHubClient.tsx` |
+| `/ica-miami` | `icaMiami.ts` | `IcaMiamiPageClient.tsx` |
 | `/bakehouse` | `bakehouse.ts` | `BakehousePageClient.tsx` |
 | `/workshops` | `workshopsOfferings.ts` | `WorkshopClient.tsx` |
 | `/artist-sustainability` | `artistSustainability.ts` | `ArtistSustainabilityClient.tsx` |

--- a/docs/site-health.md
+++ b/docs/site-health.md
@@ -42,7 +42,7 @@ Use this table to resume work. Update when a pass ships.
 The site has **two institutional doors** and **three hiring flagships**. Conversion lifts come from deepening those proofs — not from more thin `/opportunities/*` pages.
 
 ```text
-Institutions send:  /artist-infrastructure  →  /oolite-arts (proof)  →  Calendly
+Institutions send:  /institutions (museum digital systems)  →  /oolite-arts · /ica-miami (proof)  →  Calendly
 Hiring flagships:   /projects/agentic-ops · /forward-deployed · /creative-ai
 Hiring skills SoT:  /capabilities  →  private /opportunities/[slug] (thin overlays)
 Do not mix doors:   incubators ≠ /ai-engineering; hiring ≠ /artist-infrastructure alone
@@ -66,7 +66,7 @@ Standalone MCP demo, RAG demo, FastAPI demo, pgvector demo, Claude demo, OAuth d
 
 | Family | Primary send URL | Also | Audience |
 |---|---|---|---|
-| Institutions / Miami outreach | `/artist-infrastructure` | `/oolite-arts`, `/institutions`, `/bakehouse`, `/workshops` | Incubators, orgs, partners |
+| Institutions / Miami outreach | `/institutions` | `/artist-infrastructure`, `/oolite-arts`, `/ica-miami`, `/bakehouse`, `/workshops` | Museum digital systems, incubators, partners |
 | Digilab proof | `/oolite-arts` | Digilab media registry | Curators, panels, partners needing depth |
 | **Hiring flagship — agents** | `/projects/agentic-ops` | `/ai-engineering`, `/capabilities#ai-engineering` | Applied AI / FDE / SA (Building until gates) |
 | **Hiring flagship — FDE** | `/forward-deployed` | `/opportunities/forward-deployed-ai-engineer` overlay | Recruiters, FDE roles |

--- a/public/images/tech-logos/bloomerang.svg
+++ b/public/images/tech-logos/bloomerang.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 220 36" role="img" aria-label="Bloomerang">
+  <title>Bloomerang</title>
+  <text x="0" y="26" font-family="ui-sans-serif, system-ui, sans-serif" font-size="24" font-weight="700" fill="#E85D04">Bloomerang</text>
+</svg>

--- a/src/app/(main)/ica-miami/page.tsx
+++ b/src/app/(main)/ica-miami/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from 'next';
+import { IcaMiamiPageClient } from '@/components/institutions/IcaMiamiPageClient';
+import { icaMiamiPage } from '@/content/institutions/icaMiami';
+
+const { meta } = icaMiamiPage;
+
+export const metadata: Metadata = {
+  title: meta.title,
+  description: meta.description,
+  openGraph: {
+    title: meta.title,
+    description: meta.description,
+    type: 'website',
+    url: meta.url,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: meta.title,
+    description: meta.description,
+  },
+};
+
+export default function IcaMiamiPage() {
+  return <IcaMiamiPageClient />;
+}

--- a/src/app/(main)/institutions/page.tsx
+++ b/src/app/(main)/institutions/page.tsx
@@ -12,6 +12,12 @@ export const metadata: Metadata = {
     description: meta.description,
     type: 'website',
     url: meta.url,
+    images: [
+      {
+        url: 'https://res.cloudinary.com/dck5rzi4h/image/upload/v1786123448/oolite-arts/oolite-arts-digital-lab-360-photo_uaguwe.jpg',
+        alt: 'Oolite Arts Digital Lab — workstations and production room',
+      },
+    ],
   },
   twitter: {
     card: 'summary_large_image',
@@ -20,6 +26,54 @@ export const metadata: Metadata = {
   },
 };
 
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'Person',
+      name: 'Moises Sanabria',
+      url: 'https://moises.tech',
+      jobTitle: 'Interdisciplinary artist and institutional technologist',
+      email: 'm@moises.tech',
+    },
+    {
+      '@type': 'ItemList',
+      name: 'Institutional technology practice lanes',
+      itemListElement: institutionsHub.lanes.map((lane, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        item: {
+          '@type': 'Service',
+          name: lane.title,
+          description: lane.description,
+          url: `https://moises.tech/institutions#${lane.id}`,
+        },
+      })),
+    },
+    {
+      '@type': 'ItemList',
+      name: 'Flagship institutional case studies',
+      itemListElement: institutionsHub.flagship.map((study, index) => ({
+        '@type': 'ListItem',
+        position: index + 1,
+        item: {
+          '@type': 'CreativeWork',
+          name: `${study.institution}: ${study.headline}`,
+          url: `https://moises.tech${study.href}`,
+        },
+      })),
+    },
+  ],
+};
+
 export default function InstitutionsPage() {
-  return <InstitutionsHubClient />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <InstitutionsHubClient />
+    </>
+  );
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -23,6 +23,7 @@ const ROUTES: { path: string; changeFrequency: MetadataRoute.Sitemap[0]['changeF
     { path: '/artist-infrastructure', changeFrequency: 'monthly', priority: 0.85 },
     { path: '/oolite-arts', changeFrequency: 'monthly', priority: 0.85 },
     { path: '/institutions', changeFrequency: 'monthly', priority: 0.8 },
+    { path: '/ica-miami', changeFrequency: 'monthly', priority: 0.75 },
     { path: '/bakehouse', changeFrequency: 'monthly', priority: 0.75 },
     { path: '/services/smartsign', changeFrequency: 'monthly', priority: 0.75 },
     { path: '/ai24', changeFrequency: 'monthly', priority: 0.8 },

--- a/src/components/institutions/CompoundingSystem.tsx
+++ b/src/components/institutions/CompoundingSystem.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { institutionsHub as H, type PracticeLaneAccent } from '@/content/institutions/hub';
+import {
+  INST_ACCENT,
+  InstContainer,
+  InstReveal,
+  InstSectionLabel,
+  LANE_ACCENT,
+} from '@/components/institutions/InstitutionalUi';
+import { cn } from '@/lib/utils';
+
+export function InstitutionalProofStrip() {
+  return (
+    <section
+      id="proof"
+      className="scroll-mt-32 border-b border-neutral-200 py-10 sm:py-12"
+      aria-labelledby="proof-heading"
+    >
+      <InstContainer>
+        <InstReveal>
+          <h2 id="proof-heading" className="sr-only">
+            {H.proof.eyebrow}
+          </h2>
+          <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-neutral-500">
+            {H.proof.eyebrow}
+          </p>
+        </InstReveal>
+        <ul className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {H.proof.items.map((item, i) => {
+            const accent = INST_ACCENT[LANE_ACCENT[item.accent as PracticeLaneAccent]];
+            const inner = (
+              <>
+                <span className={cn('mb-3 block h-1 w-8', accent.bar)} aria-hidden />
+                <p className="font-['MoMA_Sans'] text-base font-semibold">{item.name}</p>
+                <p className="mt-1 text-sm text-neutral-700">{item.role}</p>
+                <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+                  {item.dates}
+                </p>
+              </>
+            );
+            const className = cn(
+              'block h-full border border-neutral-200 bg-white p-4 transition hover:shadow-sm',
+              accent.ring,
+              'hover:ring-2',
+            );
+            return (
+              <InstReveal key={item.id} delay={0.04 * i}>
+                <li>
+                  {'external' in item && item.external ? (
+                    <a href={item.href} target="_blank" rel="noopener noreferrer" className={className}>
+                      {inner}
+                    </a>
+                  ) : (
+                    <Link href={item.href} className={className}>
+                      {inner}
+                    </Link>
+                  )}
+                </li>
+              </InstReveal>
+            );
+          })}
+        </ul>
+      </InstContainer>
+    </section>
+  );
+}
+
+export function CompoundingSystem() {
+  return (
+    <section
+      id="system"
+      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      aria-labelledby="system-heading"
+    >
+      <InstContainer>
+        <InstReveal>
+          <InstSectionLabel accent="teal">{H.system.eyebrow}</InstSectionLabel>
+          <h2 id="system-heading" className="max-w-3xl font-['MoMA_Sans'] text-[clamp(1.75rem,3.5vw,3rem)] font-semibold">
+            {H.system.title}
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+            {H.system.caption}
+          </p>
+        </InstReveal>
+        <ol className="mt-10 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {H.system.steps.map((step, i) => (
+            <InstReveal key={step.id} delay={0.04 * i}>
+              <li className="h-full border border-neutral-200 bg-white p-5">
+                <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-neutral-500">
+                  {String(i + 1).padStart(2, '0')}
+                </p>
+                <h3 className="mt-2 font-['MoMA_Sans'] text-lg font-semibold">{step.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-neutral-700">{step.body}</p>
+              </li>
+            </InstReveal>
+          ))}
+        </ol>
+        <p className="mt-8 max-w-3xl border-l-2 border-teal-700 bg-teal-50/60 py-3 pl-4 text-sm leading-relaxed text-neutral-800">
+          {H.system.callout}
+        </p>
+      </InstContainer>
+    </section>
+  );
+}

--- a/src/components/institutions/EngagementModes.tsx
+++ b/src/components/institutions/EngagementModes.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { Layers3, Search, Wrench, type LucideIcon } from 'lucide-react';
+import { institutionsHub as H } from '@/content/institutions/hub';
+import { track } from '@/lib/analytics';
+import {
+  INST_ACCENT,
+  InstContainer,
+  InstPrimaryCta,
+  InstReveal,
+  InstSecondaryCta,
+  InstSectionLabel,
+} from '@/components/institutions/InstitutionalUi';
+
+const PROCESS_ICON: Record<(typeof H.process.steps)[number]['icon'], LucideIcon> = {
+  search: Search,
+  wrench: Wrench,
+  layers: Layers3,
+};
+
+export function ProcessSteps() {
+  return (
+    <section
+      id="process"
+      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      aria-labelledby="process-heading"
+    >
+      <InstContainer>
+        <InstReveal>
+          <InstSectionLabel accent="teal">{H.process.eyebrow}</InstSectionLabel>
+          <h2 id="process-heading" className="font-['MoMA_Sans'] text-[clamp(1.75rem,3.5vw,3rem)] font-semibold">
+            {H.process.title}
+          </h2>
+        </InstReveal>
+        <ol className="mt-10 grid gap-4 md:grid-cols-3">
+          {H.process.steps.map((step, i) => {
+            const Icon = PROCESS_ICON[step.icon];
+            return (
+              <InstReveal key={step.id} delay={0.05 * i}>
+                <li className="h-full border border-neutral-200 bg-white p-5 sm:p-6">
+                  <span className="inline-flex h-10 w-10 items-center justify-center bg-neutral-950 text-white" aria-hidden>
+                    <Icon className="h-5 w-5" strokeWidth={1.75} />
+                  </span>
+                  <p className="mt-4 font-mono text-[11px] uppercase tracking-[0.16em] text-neutral-500">
+                    {String(i + 1).padStart(2, '0')}
+                  </p>
+                  <h3 className="mt-1 font-['MoMA_Sans'] text-lg font-semibold">{step.title}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-neutral-700">{step.body}</p>
+                </li>
+              </InstReveal>
+            );
+          })}
+        </ol>
+        <ul className="mt-8 flex flex-wrap gap-2">
+          {H.process.reassurance.map((item) => (
+            <li
+              key={item}
+              className="border border-neutral-300 bg-white px-3 py-1.5 text-xs text-neutral-700"
+            >
+              {item}
+            </li>
+          ))}
+        </ul>
+      </InstContainer>
+    </section>
+  );
+}
+
+export function EngagementModes() {
+  return (
+    <section
+      id="engage"
+      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      aria-labelledby="engage-heading"
+    >
+      <InstContainer>
+        <InstReveal>
+          <InstSectionLabel accent="copper">{H.engagement.eyebrow}</InstSectionLabel>
+          <h2 id="engage-heading" className="font-['MoMA_Sans'] text-[clamp(1.75rem,3.5vw,3rem)] font-semibold">
+            {H.engagement.title}
+          </h2>
+          <p className="mt-3 max-w-2xl text-base font-medium text-neutral-800">{H.engagement.lead}</p>
+        </InstReveal>
+        <ul className="mt-10 grid gap-4 md:grid-cols-3">
+          {H.engagement.modes.map((mode, i) => {
+            const Icon = PROCESS_ICON[mode.icon];
+            const accent = INST_ACCENT[(['ocean', 'teal', 'copper'] as const)[i] ?? 'ink'];
+            return (
+              <InstReveal key={mode.id} delay={0.05 * i}>
+                <li id={`engage-${mode.id}`} className="flex h-full flex-col border border-neutral-200 bg-white p-5 sm:p-6">
+                  <span className={`inline-flex h-10 w-10 items-center justify-center ${accent.iconBg}`} aria-hidden>
+                    <Icon className="h-5 w-5" strokeWidth={1.75} />
+                  </span>
+                  <h3 className="mt-4 font-['MoMA_Sans'] text-lg font-semibold">{mode.title}</h3>
+                  <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+                    Typical duration · {mode.duration}
+                  </p>
+                  <p className="mt-3 flex-1 text-sm leading-relaxed text-neutral-700">{mode.outcome}</p>
+                  <p className="mt-3 text-xs leading-relaxed text-neutral-500">{mode.bestFor}</p>
+                </li>
+              </InstReveal>
+            );
+          })}
+        </ul>
+        <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+          <InstPrimaryCta
+            href={H.engagement.primaryCta.href}
+            label={H.engagement.primaryCta.label}
+            external
+            onClick={() => track('institutions_cta_click', { placement: 'engagement' })}
+          />
+          <InstSecondaryCta href={H.engagement.secondaryCta.href} label={H.engagement.secondaryCta.label} />
+        </div>
+      </InstContainer>
+    </section>
+  );
+}

--- a/src/components/institutions/FlagshipCaseStudies.tsx
+++ b/src/components/institutions/FlagshipCaseStudies.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { institutionsHub as H, type InstitutionCaseStudy, type PracticeLaneAccent } from '@/content/institutions/hub';
+import { track } from '@/lib/analytics';
+import {
+  INST_ACCENT,
+  InstContainer,
+  InstReveal,
+  InstSectionLabel,
+  LANE_ACCENT,
+} from '@/components/institutions/InstitutionalUi';
+import { IcaSystemsDiagram } from '@/components/institutions/IcaSystemsDiagram';
+import { cn } from '@/lib/utils';
+
+const STATUS_CLASS = {
+  shipped: INST_ACCENT.emerald.chipActive,
+  operated: INST_ACCENT.teal.chipActive,
+  delivered: INST_ACCENT.teal.chipActive,
+  active: INST_ACCENT.copper.chipActive,
+  proposed: INST_ACCENT.sky.chipActive,
+};
+
+function StatusBadge({ label, tone }: { label: string; tone: keyof typeof STATUS_CLASS }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em]',
+        STATUS_CLASS[tone],
+      )}
+    >
+      {label}
+    </span>
+  );
+}
+
+export function FlagshipCaseStudies() {
+  return (
+    <section
+      id="work"
+      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      aria-labelledby="work-heading"
+    >
+      <InstContainer>
+        <InstReveal>
+          <InstSectionLabel>Selected institutional work</InstSectionLabel>
+          <h2 id="work-heading" className="font-['MoMA_Sans'] text-[clamp(1.75rem,3.5vw,3rem)] font-semibold">
+            Three case studies
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+            Oolite, ICA Miami, and Bakehouse first. Locust Projects and exhibition history sit below as additional evidence.
+          </p>
+        </InstReveal>
+
+        <div className="mt-12 space-y-16">
+          {H.flagship.map((study, index) => {
+            const accent = INST_ACCENT[LANE_ACCENT[study.primaryLane as PracticeLaneAccent]];
+            const reverse = index % 2 === 1;
+            return (
+              <InstReveal key={study.id}>
+                <article
+                  id={`work-${study.id}`}
+                  className="scroll-mt-32 border border-neutral-200 bg-white"
+                >
+                  <div className={cn('grid lg:grid-cols-12', reverse && 'lg:[&>*:first-child]:order-2')}>
+                    <div className="relative min-h-[240px] bg-neutral-100 lg:col-span-5">
+                      {study.media[0] ? (
+                        <Image
+                          src={study.media[0].src}
+                          alt={study.media[0].alt}
+                          fill
+                          className="object-cover"
+                          sizes="(min-width: 1024px) 42vw, 100vw"
+                        />
+                      ) : 'diagram' in study && study.diagram ? (
+                        <div className="flex h-full items-center p-4 sm:p-6">
+                          <IcaSystemsDiagram className="w-full" />
+                        </div>
+                      ) : null}
+                    </div>
+                    <div className="flex flex-col p-5 sm:p-8 lg:col-span-7">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <StatusBadge
+                          label={study.statusLabel}
+                          tone={study.status === 'active' ? 'active' : 'operated'}
+                        />
+                        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+                          {study.role} · {study.dates}
+                        </p>
+                      </div>
+                      <p className={cn('mt-4 font-mono text-[11px] uppercase tracking-[0.16em]', accent.text)}>
+                        {study.institution}
+                      </p>
+                      <h3 className="mt-2 font-['MoMA_Sans'] text-2xl font-semibold leading-snug sm:text-3xl">
+                        {study.headline}
+                      </h3>
+                      <p className="mt-3 text-sm leading-relaxed text-neutral-700 sm:text-base">{study.summary}</p>
+                      {'modules' in study && study.modules ? (
+                        <ul className="mt-4 space-y-2">
+                          {study.modules.map((mod) => (
+                            <li key={mod.label} className="flex flex-wrap items-baseline gap-2 text-sm">
+                              <StatusBadge
+                                label={mod.label}
+                                tone={mod.status === 'shipped' ? 'shipped' : 'proposed'}
+                              />
+                              <span className="text-neutral-700">{mod.text}</span>
+                            </li>
+                          ))}
+                        </ul>
+                      ) : null}
+                      <dl className="mt-5 grid gap-3 sm:grid-cols-2">
+                        {study.proofSequence.map((step) => (
+                          <div key={step.stage}>
+                            <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+                              {step.stage}
+                            </dt>
+                            <dd className="mt-1 text-sm leading-relaxed text-neutral-700">{step.text}</dd>
+                          </div>
+                        ))}
+                      </dl>
+                      <ul className="mt-5 flex flex-wrap gap-3">
+                        {study.facts.map((fact) => (
+                          <li key={fact.label} className="border border-neutral-200 bg-[#f7f6f3] px-3 py-2">
+                            <p className="font-['MoMA_Sans'] text-lg font-semibold">{fact.value}</p>
+                            <p className="text-xs text-neutral-600">{fact.label}</p>
+                          </li>
+                        ))}
+                      </ul>
+                      {study.media.length > 1 ? (
+                        <ul className="mt-5 grid grid-cols-2 gap-2">
+                          {study.media.slice(1).map((img) => (
+                            <li key={img.src} className="relative aspect-[16/10] overflow-hidden bg-neutral-200">
+                              <Image src={img.src} alt={img.alt} fill className="object-cover" sizes="200px" />
+                            </li>
+                          ))}
+                        </ul>
+                      ) : null}
+                      <Link
+                        href={study.href}
+                        className="mt-6 inline-flex min-h-11 items-center gap-2 text-sm font-semibold underline-offset-4 hover:underline"
+                        onClick={() =>
+                          track('institutions_case_study_open', {
+                            institution: study.institution,
+                            lane: study.primaryLane,
+                          })
+                        }
+                      >
+                        {study.cta}
+                        <ArrowRight className="h-4 w-4" aria-hidden />
+                      </Link>
+                    </div>
+                  </div>
+                </article>
+              </InstReveal>
+            );
+          })}
+        </div>
+      </InstContainer>
+    </section>
+  );
+}
+
+export function AdditionalEvidence() {
+  return (
+    <section
+      id="evidence"
+      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      aria-labelledby="evidence-heading"
+    >
+      <InstContainer>
+        <InstReveal>
+          <InstSectionLabel accent="rose">Additional evidence</InstSectionLabel>
+          <h2 id="evidence-heading" className="font-['MoMA_Sans'] text-[clamp(1.75rem,3.5vw,3rem)] font-semibold">
+            Workshops, platforms, and exhibition context
+          </h2>
+        </InstReveal>
+        <ul className="mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {H.additionalEvidence.map((study, i) => (
+            <InstReveal key={study.id} delay={0.03 * i}>
+              <li>
+                <EvidenceCard study={study} />
+              </li>
+            </InstReveal>
+          ))}
+        </ul>
+
+        <div className="mt-16 border border-neutral-950 bg-neutral-950 p-6 text-white sm:p-8">
+          <h3 className="font-['MoMA_Sans'] text-xl font-semibold sm:text-2xl">{H.artBand.title}</h3>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-white/75">{H.artBand.body}</p>
+          <ul className="mt-6 grid grid-cols-2 gap-2 sm:grid-cols-4">
+            {H.artBand.items.map((item) => (
+              <li key={item.label}>
+                <Link href={item.href} className="group block">
+                  <div className="relative aspect-[4/3] overflow-hidden bg-neutral-800">
+                    <Image
+                      src={item.src}
+                      alt={item.alt}
+                      fill
+                      className="object-cover transition duration-500 group-hover:scale-[1.03] motion-reduce:group-hover:scale-100"
+                      sizes="(max-width: 640px) 50vw, 20vw"
+                    />
+                  </div>
+                  <p className="mt-2 font-mono text-[10px] uppercase tracking-[0.12em] text-white/70">
+                    {item.label}
+                  </p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </InstContainer>
+    </section>
+  );
+}
+
+function EvidenceCard({ study }: { study: InstitutionCaseStudy }) {
+  const inner = (
+    <>
+      <div className="relative aspect-[16/10] overflow-hidden bg-neutral-200">
+        {study.imageSrc ? (
+          <Image
+            src={study.imageSrc}
+            alt={study.imageAlt || study.title}
+            fill
+            className="object-cover transition duration-500 group-hover:scale-[1.02] motion-reduce:group-hover:scale-100"
+            sizes="(max-width: 768px) 100vw, 33vw"
+          />
+        ) : null}
+        <span className="absolute left-3 top-3 border border-white/40 bg-white/90 px-2 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-[0.12em]">
+          {study.kindLabel}
+        </span>
+      </div>
+      <div className="flex flex-1 flex-col p-5">
+        <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-neutral-500">{study.org}</p>
+        <h3 className="mt-2 font-['MoMA_Sans'] text-lg font-semibold leading-snug">{study.title}</h3>
+        <p className="mt-2 flex-1 text-sm leading-relaxed text-neutral-700">{study.body}</p>
+        <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold">
+          Open
+          <ArrowRight className="h-3.5 w-3.5" aria-hidden />
+        </span>
+      </div>
+    </>
+  );
+
+  const className =
+    'group flex h-full flex-col overflow-hidden border border-neutral-200 bg-white transition hover:shadow-sm';
+
+  if (study.external) {
+    return (
+      <a href={study.href} target="_blank" rel="noopener noreferrer" className={className}>
+        {inner}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={study.href} className={className}>
+      {inner}
+    </Link>
+  );
+}

--- a/src/components/institutions/IcaMiamiPageClient.tsx
+++ b/src/components/institutions/IcaMiamiPageClient.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { icaMiamiPage as P } from '@/content/institutions/icaMiami';
+import { track } from '@/lib/analytics';
+import {
+  InstContainer,
+  InstFamilyNav,
+  InstPageShell,
+  InstPrimaryCta,
+  InstReveal,
+  InstSecondaryCta,
+  InstSectionLabel,
+} from '@/components/institutions/InstitutionalUi';
+import { IcaSystemsDiagram } from '@/components/institutions/IcaSystemsDiagram';
+
+export function IcaMiamiPageClient() {
+  return (
+    <InstPageShell className="pt-[192px]">
+      <InstFamilyNav active="institutions" className="sticky top-0 z-40" />
+      <header className="border-b border-neutral-200">
+        <InstContainer className="py-14 sm:py-20">
+          <InstReveal>
+            <InstSectionLabel accent="ocean">{P.hero.eyebrow}</InstSectionLabel>
+            <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-neutral-500">
+              {P.hero.status} · {P.hero.dates}
+            </p>
+            <h1 className="mt-3 max-w-3xl font-['MoMA_Sans'] text-3xl font-semibold leading-[1.12] tracking-tight sm:text-4xl md:text-5xl">
+              {P.hero.headline}
+            </h1>
+            <p className="mt-5 max-w-2xl text-base leading-relaxed text-neutral-700 sm:text-lg">
+              {P.hero.lead}
+            </p>
+            <p className="mt-4 font-mono text-[11px] uppercase tracking-[0.14em] text-neutral-500">
+              {P.hero.availability}
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <InstPrimaryCta
+                href={P.ctas.primary.href}
+                label={P.ctas.primary.label}
+                external
+                onClick={() => track('institutions_cta_click', { placement: 'ica_hero' })}
+              />
+              <InstSecondaryCta href={P.ctas.back.href} label={P.ctas.back.label} />
+            </div>
+          </InstReveal>
+        </InstContainer>
+      </header>
+
+      <section className="border-b border-neutral-200 py-14 sm:py-16" aria-labelledby="ica-diagram-heading">
+        <InstContainer>
+          <InstReveal>
+            <h2 id="ica-diagram-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+              Salesforce, web, and livestream as one workflow
+            </h2>
+            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+              The public site, collection data, ticketing, and remote programs had to stay connected without a new vendor for every update.
+            </p>
+            <IcaSystemsDiagram className="mt-8" />
+          </InstReveal>
+        </InstContainer>
+      </section>
+
+      <section className="border-b border-neutral-200 py-14 sm:py-16" aria-labelledby="ica-capabilities-heading">
+        <InstContainer>
+          <InstReveal>
+            <InstSectionLabel accent="ocean">Verified capabilities</InstSectionLabel>
+            <h2 id="ica-capabilities-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+              What the Digital Producer role covered
+            </h2>
+          </InstReveal>
+          <ul className="mt-8 grid gap-4 sm:grid-cols-2">
+            {P.capabilities.map((item) => (
+              <li key={item.title} className="border border-neutral-200 bg-white p-5">
+                <h3 className="font-['MoMA_Sans'] text-lg font-semibold">{item.title}</h3>
+                <p className="mt-2 text-sm leading-relaxed text-neutral-700">{item.body}</p>
+              </li>
+            ))}
+          </ul>
+        </InstContainer>
+      </section>
+
+      <section className="border-b border-neutral-200 py-14 sm:py-16" aria-labelledby="ica-sequence-heading">
+        <InstContainer>
+          <InstReveal>
+            <h2 id="ica-sequence-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+              Need → system → use → capacity
+            </h2>
+          </InstReveal>
+          <dl className="mt-8 grid gap-4 sm:grid-cols-2">
+            {P.proofSequence.map((step) => (
+              <div key={step.stage} className="border-l-2 border-sky-700 bg-sky-50/50 py-3 pl-4">
+                <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-sky-900">{step.stage}</dt>
+                <dd className="mt-1 text-sm leading-relaxed text-neutral-800">{step.text}</dd>
+              </div>
+            ))}
+          </dl>
+        </InstContainer>
+      </section>
+
+      <section className="py-14 sm:py-16" aria-labelledby="ica-later-heading">
+        <InstContainer>
+          <InstReveal>
+            <InstSectionLabel>{P.laterContext.title}</InstSectionLabel>
+            <h2 id="ica-later-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
+              Exhibition credit, not employment proof
+            </h2>
+            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+              {P.laterContext.body}
+            </p>
+            <figure className="mt-8 max-w-xl">
+              <div className="relative aspect-[16/7] overflow-hidden bg-neutral-200">
+                <Image
+                  src={P.laterContext.image.src}
+                  alt={P.laterContext.image.alt}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 768px) 100vw, 576px"
+                />
+              </div>
+              <figcaption className="mt-2 text-xs text-neutral-500">
+                {P.laterContext.image.alt}
+              </figcaption>
+            </figure>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+              <InstPrimaryCta
+                href={P.ctas.primary.href}
+                label={P.ctas.primary.label}
+                external
+                onClick={() => track('institutions_cta_click', { placement: 'ica_footer' })}
+              />
+              <Link
+                href={`mailto:${P.ctas.email}`}
+                className="inline-flex min-h-11 items-center justify-center border border-neutral-300 bg-white px-5 py-2.5 text-sm font-medium"
+              >
+                {P.ctas.email}
+              </Link>
+            </div>
+          </InstReveal>
+        </InstContainer>
+      </section>
+    </InstPageShell>
+  );
+}

--- a/src/components/institutions/IcaSystemsDiagram.tsx
+++ b/src/components/institutions/IcaSystemsDiagram.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import Image from 'next/image';
+import { ArrowRight, Database, RadioTower, Workflow } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Reconstructed ICA digital-production map.
+ * Marked as reconstructed — no private Salesforce, donor, or member data.
+ */
+export function IcaSystemsDiagram({ className }: { className?: string }) {
+  return (
+    <figure
+      className={cn(
+        'border border-sky-200 bg-sky-50/70 p-4 sm:p-6',
+        className,
+      )}
+    >
+      <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-sky-900">
+        System diagram · reconstructed from project work
+      </p>
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <DiagramNode
+          icon={Database}
+          title="Salesforce"
+          body="Collection records"
+        />
+        <DiagramNode
+          icon={Workflow}
+          title="WordPress + ticketing"
+          body="Public pages, registration"
+        />
+        <DiagramNode
+          icon={RadioTower}
+          title="OBS + YouTube"
+          body="Programs, captions"
+        />
+      </div>
+      <p className="mt-4 flex flex-wrap items-center gap-2 text-xs leading-relaxed text-sky-950/80">
+        <span className="inline-flex items-center gap-1 font-medium">
+          Salesforce
+          <ArrowRight className="h-3 w-3" aria-hidden />
+          WordPress / ticketing
+        </span>
+        <span aria-hidden>·</span>
+        <span className="inline-flex items-center gap-1 font-medium">
+          GitHub / GraphQL
+          <ArrowRight className="h-3 w-3" aria-hidden />
+          AWS CloudFront
+        </span>
+        <span aria-hidden>·</span>
+        <span className="inline-flex items-center gap-1 font-medium">
+          OBS
+          <ArrowRight className="h-3 w-3" aria-hidden />
+          captions / YouTube
+        </span>
+      </p>
+      <figcaption className="mt-3 text-xs leading-relaxed text-neutral-600">
+        Museum data, public web, and livestream production as one connected workflow—not three vendor silos.
+      </figcaption>
+    </figure>
+  );
+}
+
+function DiagramNode({
+  icon: Icon,
+  title,
+  body,
+}: {
+  icon: typeof Database;
+  title: string;
+  body: string;
+}) {
+  return (
+    <div className="border border-sky-200 bg-white p-3">
+      <Icon className="h-5 w-5 text-sky-800" strokeWidth={1.75} aria-hidden />
+      <p className="mt-2 font-['MoMA_Sans'] text-sm font-semibold">{title}</p>
+      <p className="mt-0.5 text-xs text-neutral-600">{body}</p>
+    </div>
+  );
+}
+
+export function LaneStackVisual({
+  logos,
+  accentClass,
+}: {
+  logos: readonly { src: string; alt: string; height?: number }[];
+  accentClass?: string;
+}) {
+  if (!logos.length) return null;
+  return (
+    <ul className={cn('mt-4 flex flex-wrap items-center gap-3', accentClass)} aria-label="Software in this lane">
+      {logos.map((logo) => (
+        <li key={logo.alt} className="flex h-9 items-center border border-neutral-200 bg-white px-2.5">
+          <Image
+            src={logo.src}
+            alt={logo.alt}
+            width={Math.round((logo.height ?? 28) * 3)}
+            height={logo.height ?? 28}
+            className="h-5 w-auto max-w-[88px] object-contain"
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/institutions/InstitutionArchive.tsx
+++ b/src/components/institutions/InstitutionArchive.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { ArrowRight, ArrowUpRight } from 'lucide-react';
+import {
+  institutionsHub as H,
+  type InstitutionOrg,
+  type OrgRelationship,
+} from '@/content/institutions/hub';
+import { track } from '@/lib/analytics';
+import {
+  INST_ACCENT,
+  InstContainer,
+  InstReveal,
+  InstSectionLabel,
+} from '@/components/institutions/InstitutionalUi';
+import { cn } from '@/lib/utils';
+
+const ORG_FILTERS: Array<{ id: 'all' | OrgRelationship; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'employment', label: 'Employment' },
+  { id: 'lab', label: 'Lab' },
+  { id: 'residency', label: 'Residency' },
+  { id: 'workshop', label: 'Teaching' },
+  { id: 'platform', label: 'Platform' },
+  { id: 'exhibition', label: 'Exhibition' },
+  { id: 'festival', label: 'Festival' },
+  { id: 'education', label: 'Education' },
+  { id: 'funder', label: 'Funder context' },
+];
+
+export function InstitutionArchive() {
+  const [orgFilter, setOrgFilter] = useState<'all' | OrgRelationship>('all');
+  const [expanded, setExpanded] = useState(false);
+
+  const filtered = useMemo(() => {
+    if (orgFilter === 'all') return H.organizations;
+    return H.organizations.filter((o) => o.relationship === orgFilter);
+  }, [orgFilter]);
+
+  const visible = useMemo(() => {
+    if (expanded || orgFilter !== 'all') return filtered;
+    return filtered.filter((o) => o.archiveFeatured);
+  }, [expanded, filtered, orgFilter]);
+
+  const hiddenCount = filtered.length - visible.length;
+
+  return (
+    <section
+      id="archive"
+      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      aria-labelledby="archive-heading"
+    >
+      <InstContainer>
+        <InstReveal>
+          <InstSectionLabel accent="ocean">Institutional experience</InstSectionLabel>
+          <h2 id="archive-heading" className="font-['MoMA_Sans'] text-[clamp(1.75rem,3.5vw,3rem)] font-semibold">
+            Institutional experience and cultural contexts
+          </h2>
+          <p className="mt-3 max-w-2xl text-sm leading-relaxed text-neutral-700 sm:text-base">
+            Secondary proof after the three flagship case studies. Relationship type is always visible.
+          </p>
+        </InstReveal>
+
+        <div
+          className="mt-6 flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          role="group"
+          aria-label="Filter institutional experience"
+        >
+          {ORG_FILTERS.map((filter) => {
+            const active = orgFilter === filter.id;
+            return (
+              <button
+                key={filter.id}
+                type="button"
+                aria-pressed={active}
+                onClick={() => {
+                  setOrgFilter(filter.id);
+                  if (filter.id !== 'all') setExpanded(true);
+                }}
+                className={cn(
+                  'min-h-11 shrink-0 border px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.12em] transition',
+                  active
+                    ? INST_ACCENT.ocean.chipActive
+                    : 'border-neutral-300 bg-white text-neutral-700 hover:border-neutral-500',
+                )}
+              >
+                {filter.label}
+              </button>
+            );
+          })}
+        </div>
+
+        <ul className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {visible.map((org, i) => (
+            <InstReveal key={org.id} delay={Math.min(0.03 * i, 0.24)}>
+              <li>
+                <OrgCard org={org} />
+              </li>
+            </InstReveal>
+          ))}
+        </ul>
+
+        {hiddenCount > 0 ? (
+          <button
+            type="button"
+            className="mt-8 inline-flex min-h-11 items-center border border-neutral-950 bg-white px-5 py-2.5 text-sm font-semibold"
+            onClick={() => {
+              setExpanded(true);
+              track('institutions_archive_expand');
+            }}
+          >
+            View full experience ({hiddenCount} more)
+          </button>
+        ) : null}
+
+        <details className="mt-8 max-w-xl text-xs text-neutral-500">
+          <summary className="cursor-pointer font-mono uppercase tracking-[0.12em]">
+            How this list is verified
+          </summary>
+          <p className="mt-2 leading-relaxed">{H.honestyNote}</p>
+        </details>
+      </InstContainer>
+    </section>
+  );
+}
+
+function OrgCard({ org }: { org: InstitutionOrg }) {
+  const body = (
+    <>
+      {org.imageSrc ? (
+        <div className="relative aspect-[16/10] overflow-hidden bg-neutral-200">
+          <Image
+            src={org.imageSrc}
+            alt={org.imageAlt ?? org.name}
+            fill
+            className="object-cover"
+            sizes="(max-width: 640px) 100vw, 33vw"
+          />
+        </div>
+      ) : (
+        <div className="flex aspect-[16/10] items-center justify-center bg-neutral-100 px-4 text-center">
+          <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-neutral-500">
+            {org.relationshipLabel}
+          </p>
+        </div>
+      )}
+      <div className="flex flex-1 flex-col p-4 sm:p-5">
+        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
+          {org.relationshipLabel}
+        </p>
+        <h3 className="mt-1.5 font-['MoMA_Sans'] text-base font-semibold leading-snug sm:text-lg">
+          {org.name}
+        </h3>
+        <p className="mt-1 text-xs text-neutral-500">{org.location}</p>
+        <p className="mt-2 flex-1 text-sm leading-relaxed text-neutral-700">{org.summary}</p>
+        {org.href ? (
+          <span className="mt-3 inline-flex items-center gap-1 text-sm font-semibold">
+            View
+            {org.external ? (
+              <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
+            ) : (
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden />
+            )}
+          </span>
+        ) : null}
+      </div>
+    </>
+  );
+
+  const className =
+    'group flex h-full flex-col overflow-hidden border border-neutral-200 bg-white transition hover:border-neutral-400';
+
+  if (!org.href) {
+    return <div className={className}>{body}</div>;
+  }
+
+  if (org.external) {
+    return (
+      <a href={org.href} target="_blank" rel="noopener noreferrer" className={className}>
+        {body}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={org.href} className={className}>
+      {body}
+    </Link>
+  );
+}

--- a/src/components/institutions/InstitutionalUi.tsx
+++ b/src/components/institutions/InstitutionalUi.tsx
@@ -26,7 +26,7 @@ import { cn } from '@/lib/utils';
 
 /** Accent tokens — color-coded without purple-gradient AI look. */
 export const INST_ACCENT: Record<
-  InstitutionalAccent | 'rose' | 'sky' | 'emerald',
+  InstitutionalAccent | 'rose' | 'sky' | 'emerald' | 'violet',
   {
     chip: string;
     chipActive: string;
@@ -116,7 +116,26 @@ export const INST_ACCENT: Record<
     ring: 'ring-emerald-700/20',
     iconBg: 'bg-emerald-700 text-white',
   },
+  violet: {
+    chip: 'border-violet-200 bg-violet-50 text-violet-950 hover:border-violet-400',
+    chipActive: 'border-violet-800 bg-violet-800 text-white',
+    chipDark: 'border-violet-300/30 bg-violet-950/40 text-violet-100 hover:border-violet-300/60',
+    chipDarkActive: 'border-violet-300 bg-violet-300 text-violet-950',
+    bar: 'bg-violet-800',
+    soft: 'bg-violet-50',
+    text: 'text-violet-950',
+    ring: 'ring-violet-700/20',
+    iconBg: 'bg-violet-800 text-white',
+  },
 };
+
+/** Semantic colors for /institutions practice lanes. */
+export const LANE_ACCENT = {
+  web: 'ocean',
+  automation: 'teal',
+  live: 'violet',
+  lab: 'copper',
+} as const satisfies Record<string, keyof typeof INST_ACCENT>;
 
 const FAMILY_ICONS: Record<InstitutionalFamilyMatch, LucideIcon> = {
   'artist-infrastructure': Network,

--- a/src/components/institutions/InstitutionsFinalCTA.tsx
+++ b/src/components/institutions/InstitutionsFinalCTA.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import Image from 'next/image';
+import { institutionsHub as H } from '@/content/institutions/hub';
+import { track } from '@/lib/analytics';
+import {
+  InstContainer,
+  InstReveal,
+  InstSecondaryCta,
+} from '@/components/institutions/InstitutionalUi';
+
+export function InstitutionsFinalCTA() {
+  return (
+    <section
+      id="contact"
+      className="scroll-mt-32 bg-neutral-950 py-16 text-white sm:py-20"
+      aria-labelledby="contact-heading"
+    >
+      <InstContainer>
+        <InstReveal>
+          <div className="grid items-center gap-10 lg:grid-cols-12">
+            <div className="lg:col-span-8">
+              <h2 id="contact-heading" className="font-['MoMA_Sans'] text-[clamp(1.75rem,3.5vw,3rem)] font-semibold leading-tight">
+                {H.contact.headline}
+              </h2>
+              <p className="mt-4 max-w-2xl text-sm leading-relaxed text-white/75 sm:text-base">
+                {H.contact.body}
+              </p>
+              <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                <a
+                  href={H.engagement.primaryCta.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex min-h-11 items-center justify-center bg-white px-5 py-2.5 text-sm font-semibold text-neutral-950 transition hover:bg-white/90"
+                  onClick={() => track('institutions_cta_click', { placement: 'final' })}
+                >
+                  {H.engagement.primaryCta.label}
+                </a>
+                <a
+                  href={`mailto:${H.contact.email}`}
+                  className="inline-flex min-h-11 items-center justify-center border border-white/40 px-5 py-2.5 text-sm font-medium text-white"
+                  onClick={() => track('institutions_email_click')}
+                >
+                  {H.contact.email}
+                </a>
+                <InstSecondaryCta href={H.contact.cvHref} label="Download technology CV" />
+              </div>
+            </div>
+            <div className="lg:col-span-4">
+              <div className="relative mx-auto aspect-[4/5] max-w-[280px] overflow-hidden bg-neutral-800">
+                <Image
+                  src={H.contact.image.src}
+                  alt={H.contact.image.alt}
+                  fill
+                  className="object-cover"
+                  sizes="280px"
+                />
+              </div>
+            </div>
+          </div>
+        </InstReveal>
+      </InstContainer>
+    </section>
+  );
+}

--- a/src/components/institutions/InstitutionsHero.tsx
+++ b/src/components/institutions/InstitutionsHero.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import Image from 'next/image';
+import { OpportunityProfileImage } from '@/components/opportunities/OpportunityProfileImage';
+import { OpportunityAudienceKeywords } from '@/components/opportunities/OpportunityAudienceKeywords';
+import { AnimatedLogoBand } from '@/components/opportunities/AnimatedLogoBand';
+import { track } from '@/lib/analytics';
+import { institutionsHub as H } from '@/content/institutions/hub';
+import {
+  InstContainer,
+  InstPrimaryCta,
+  InstSecondaryCta,
+  InstSectionLabel,
+} from '@/components/institutions/InstitutionalUi';
+
+export function InstitutionsHero() {
+  const { collage } = H.hero;
+
+  return (
+    <header id="top" className="scroll-mt-32 border-b border-neutral-200">
+      <InstContainer className="py-12 sm:py-16 md:py-20">
+        <div className="grid items-start gap-10 lg:grid-cols-12 lg:gap-12">
+          <div className="lg:col-span-7">
+            <InstSectionLabel>{H.hero.eyebrow}</InstSectionLabel>
+            <h1 className="max-w-3xl font-['MoMA_Sans'] text-[clamp(2.25rem,5.5vw,4.25rem)] font-semibold leading-[1.08] tracking-tight">
+              {H.hero.headline}
+            </h1>
+            <p className="mt-5 max-w-[42rem] text-base leading-relaxed text-neutral-700 sm:text-lg">
+              {H.hero.lead}
+            </p>
+            <p className="mt-4 max-w-[42rem] text-sm leading-relaxed text-neutral-600 sm:text-base">
+              {H.hero.support}
+            </p>
+            <p className="mt-4 font-mono text-[11px] uppercase tracking-[0.14em] text-neutral-500">
+              {H.hero.availabilityLabel}
+            </p>
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <InstPrimaryCta
+                href={H.hero.primaryCta.href}
+                label={H.hero.primaryCta.label}
+                external={H.hero.primaryCta.external}
+                onClick={() =>
+                  track('institutions_cta_click', { placement: 'hero' })
+                }
+              />
+              <InstSecondaryCta
+                href={H.hero.secondaryCta.href}
+                label={H.hero.secondaryCta.label}
+              />
+            </div>
+          </div>
+
+          <div className="lg:col-span-5">
+            <div className="grid grid-cols-2 gap-2 sm:gap-3">
+              <div className="col-span-2">
+                <div className="relative aspect-[16/9] overflow-hidden bg-neutral-200">
+                  <Image
+                    src={collage.main.src}
+                    alt={collage.main.alt}
+                    fill
+                    priority
+                    className="object-cover"
+                    sizes="(min-width: 1024px) 42vw, 100vw"
+                  />
+                </div>
+                <p className="mt-1.5 text-xs leading-relaxed text-neutral-600">{collage.main.caption}</p>
+              </div>
+              <div>
+                <div className="relative aspect-[4/3] overflow-hidden bg-neutral-200">
+                  <Image
+                    src={collage.teaching.src}
+                    alt={collage.teaching.alt}
+                    fill
+                    className="object-cover"
+                    sizes="(min-width: 1024px) 20vw, 50vw"
+                  />
+                </div>
+                <p className="mt-1.5 text-xs leading-relaxed text-neutral-600">{collage.teaching.caption}</p>
+              </div>
+              <div>
+                <div className="relative aspect-[4/3] overflow-hidden bg-neutral-200">
+                  <Image
+                    src={collage.workflow.src}
+                    alt={collage.workflow.alt}
+                    fill
+                    className="object-cover object-left"
+                    sizes="(min-width: 1024px) 20vw, 50vw"
+                  />
+                </div>
+                <p className="mt-1.5 text-xs leading-relaxed text-neutral-600">{collage.workflow.caption}</p>
+              </div>
+              <div className="col-span-2 sm:col-span-1">
+                <p className="mb-2 font-mono text-[10px] uppercase tracking-[0.16em] text-neutral-500">
+                  {H.profile.label}
+                </p>
+                <OpportunityProfileImage
+                  src={H.profile.src}
+                  alt={H.profile.alt}
+                  sizes="(min-width: 1024px) 20vw, 50vw"
+                  frameClassName="mx-0 max-w-none"
+                  className="max-w-none"
+                />
+              </div>
+              <div className="flex items-end">
+                <p className="inline-block border border-neutral-950 bg-neutral-950 px-3 py-1.5 font-mono text-[10px] uppercase tracking-[0.14em] text-white">
+                  {collage.captionCard}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-12 border-t border-neutral-200 pt-8">
+          <OpportunityAudienceKeywords data={H.audienceKeywords} className="mb-0 text-left" />
+        </div>
+      </InstContainer>
+
+      <div className="border-t border-neutral-200 bg-white py-6 sm:py-8">
+        <InstContainer>
+          <p className="mb-4 font-mono text-[10px] uppercase tracking-[0.16em] text-neutral-500">
+            {H.logoBandLabel}
+          </p>
+        </InstContainer>
+        <AnimatedLogoBand logos={[...H.logoBand]} bleed ariaLabel={H.logoBandLabel} />
+      </div>
+    </header>
+  );
+}

--- a/src/components/institutions/InstitutionsHubClient.tsx
+++ b/src/components/institutions/InstitutionsHubClient.tsx
@@ -1,59 +1,33 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import Image from 'next/image';
-import Link from 'next/link';
-import { ArrowRight, ArrowUpRight, ExternalLink } from 'lucide-react';
-import {
-  institutionsHub,
-  type InstitutionCaseStudy,
-  type InstitutionOrg,
-  type OrgRelationship,
-} from '@/content/institutions/hub';
+import { useEffect, useState } from 'react';
+import { CalendarDays } from 'lucide-react';
+import { institutionsHub as H } from '@/content/institutions/hub';
 import { track } from '@/lib/analytics';
 import {
   InstContainer,
   InstFamilyNav,
-  InstLaneIcon,
   InstPageShell,
-  InstPrimaryCta,
-  InstReveal,
-  InstSecondaryCta,
-  InstSectionLabel,
-  INST_ACCENT,
 } from '@/components/institutions/InstitutionalUi';
-import { ProposePilotBand } from '@/components/institutions/PilotPricingBand';
+import { OpportunityApplicationBanner } from '@/components/opportunities/OpportunityApplicationBanner';
+import { InstitutionsHero } from '@/components/institutions/InstitutionsHero';
+import { InstitutionalProofStrip, CompoundingSystem } from '@/components/institutions/CompoundingSystem';
+import { PracticeLaneGrid } from '@/components/institutions/PracticeLaneGrid';
+import { AdditionalEvidence, FlagshipCaseStudies } from '@/components/institutions/FlagshipCaseStudies';
+import { EngagementModes, ProcessSteps } from '@/components/institutions/EngagementModes';
+import { InstitutionArchive } from '@/components/institutions/InstitutionArchive';
+import { InstitutionsFinalCTA } from '@/components/institutions/InstitutionsFinalCTA';
 import { cn } from '@/lib/utils';
 
-const H = institutionsHub;
-
-const SECTION_ACCENT = {
-  practice: 'teal',
-  'case-studies': 'ink',
-  organizations: 'ocean',
+const SECTION_ACCENT: Record<string, 'ink' | 'ocean' | 'teal' | 'copper' | 'violet' | 'rose'> = {
+  top: 'ink',
+  services: 'ocean',
+  system: 'teal',
+  work: 'ink',
+  evidence: 'rose',
   engage: 'copper',
-} as const;
-
-const KIND_ACCENT: Record<InstitutionCaseStudy['kind'], keyof typeof INST_ACCENT> = {
-  systems: 'teal',
-  program: 'ocean',
-  exhibition: 'rose',
-  platform: 'copper',
-  workshop: 'sky',
+  archive: 'ocean',
 };
-
-const ORG_FILTERS: Array<{ id: 'all' | OrgRelationship; label: string }> = [
-  { id: 'all', label: 'All' },
-  { id: 'lab', label: 'Lab' },
-  { id: 'residency', label: 'Residency' },
-  { id: 'employment', label: 'Employment' },
-  { id: 'platform', label: 'Platform' },
-  { id: 'workshop', label: 'Workshop' },
-  { id: 'exhibition', label: 'Exhibition' },
-  { id: 'festival', label: 'Festival' },
-  { id: 'funder', label: 'Funder' },
-  { id: 'education', label: 'Education' },
-];
 
 function scrollToId(id: string) {
   const el = document.getElementById(id);
@@ -63,440 +37,105 @@ function scrollToId(id: string) {
   window.history.replaceState(null, '', `#${id}`);
 }
 
-function CaseStudyCard({ study, large }: { study: InstitutionCaseStudy; large?: boolean }) {
-  const accentKey = KIND_ACCENT[study.kind] ?? 'ink'
-  const accent = INST_ACCENT[accentKey]
-  const inner = (
-    <>
-      <div className={cn('relative overflow-hidden bg-neutral-200', large ? 'aspect-[16/9]' : 'aspect-[16/10]')}>
-        {study.imageSrc ? (
-          <Image
-            src={study.imageSrc}
-            alt={study.imageAlt || study.title}
-            fill
-            className="object-cover transition duration-500 group-hover:scale-[1.02] motion-reduce:transition-none motion-reduce:group-hover:scale-100"
-            sizes={large ? '(max-width: 768px) 100vw, 50vw' : '(max-width: 768px) 100vw, 33vw'}
-          />
-        ) : null}
-        <span
-          className={cn(
-            'absolute left-3 top-3 border px-2 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-[0.12em] backdrop-blur-sm',
-            accent.chipActive,
-          )}
-        >
-          {study.kindLabel}
-        </span>
-      </div>
-      <div className="flex flex-1 flex-col p-5 sm:p-6">
-        <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-neutral-500">
-          {study.org}
-        </p>
-        <h3 className="mt-2 font-['MoMA_Sans'] text-lg font-semibold leading-snug sm:text-xl">
-          {study.title}
-        </h3>
-        <p className="mt-2 flex-1 text-sm leading-relaxed text-neutral-700">{study.body}</p>
-        <span className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold">
-          {study.external ? 'Open external' : 'Open case study'}
-          {study.external ? (
-            <ExternalLink className="h-3.5 w-3.5" aria-hidden />
-          ) : (
-            <ArrowRight className="h-3.5 w-3.5 transition group-hover:translate-x-0.5" aria-hidden />
-          )}
-        </span>
-      </div>
-    </>
-  );
-
-  const className = cn(
-    'group flex h-full flex-col border border-neutral-200 bg-white transition hover:shadow-sm',
-    'hover:ring-2',
-    accent.ring,
-  );
-
-  if (study.external) {
-    return (
-      <a href={study.href} target="_blank" rel="noopener noreferrer" className={className}>
-        {inner}
-      </a>
-    );
-  }
-
-  return (
-    <Link href={study.href} className={className}>
-      {inner}
-    </Link>
-  );
-}
-
-function OrgCard({ org }: { org: InstitutionOrg }) {
-  const body = (
-    <>
-      {org.imageSrc ? (
-        <div className="relative aspect-[16/10] overflow-hidden bg-neutral-200">
-          <Image
-            src={org.imageSrc}
-            alt={org.imageAlt ?? org.name}
-            fill
-            className="object-cover"
-            sizes="(max-width: 640px) 100vw, 33vw"
-          />
-        </div>
-      ) : (
-        <div className="flex aspect-[16/10] items-center justify-center bg-neutral-100 px-4 text-center">
-          <p className="font-mono text-[11px] uppercase tracking-[0.14em] text-neutral-500">
-            {org.relationshipLabel}
-          </p>
-        </div>
-      )}
-      <div className="flex flex-1 flex-col p-4 sm:p-5">
-        <p className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
-          {org.relationshipLabel}
-        </p>
-        <h3 className="mt-1.5 font-['MoMA_Sans'] text-base font-semibold leading-snug sm:text-lg">
-          {org.name}
-        </h3>
-        <p className="mt-1 text-xs text-neutral-500">{org.location}</p>
-        <p className="mt-2 flex-1 text-sm leading-relaxed text-neutral-700">{org.summary}</p>
-        {org.href ? (
-          <span className="mt-3 inline-flex items-center gap-1 text-sm font-semibold">
-            View
-            {org.external ? (
-              <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
-            ) : (
-              <ArrowRight className="h-3.5 w-3.5" aria-hidden />
-            )}
-          </span>
-        ) : null}
-      </div>
-    </>
-  );
-
-  const className =
-    'group flex h-full flex-col overflow-hidden border border-neutral-200 bg-white transition hover:border-neutral-400';
-
-  if (!org.href) {
-    return <div className={className}>{body}</div>;
-  }
-
-  if (org.external) {
-    return (
-      <a href={org.href} target="_blank" rel="noopener noreferrer" className={className}>
-        {body}
-      </a>
-    );
-  }
-
-  return (
-    <Link href={org.href} className={className}>
-      {body}
-    </Link>
-  );
-}
-
 export function InstitutionsHubClient() {
-  const [activeNav, setActiveNav] = useState('practice');
-  const [orgFilter, setOrgFilter] = useState<'all' | OrgRelationship>('all');
-
-  const featured = useMemo(
-    () => H.caseStudies.filter((c) => c.featured),
-    [],
-  );
-  const moreStudies = useMemo(
-    () => H.caseStudies.filter((c) => !c.featured),
-    [],
-  );
-
-  const filteredOrgs = useMemo(() => {
-    if (orgFilter === 'all') return H.organizations;
-    return H.organizations.filter((o) => o.relationship === orgFilter);
-  }, [orgFilter]);
+  const [activeNav, setActiveNav] = useState('top');
 
   useEffect(() => {
     const ids = H.nav.map((n) => n.id);
-    const onScroll = () => {
-      let current = ids[0];
-      for (const id of ids) {
-        const el = document.getElementById(id);
-        if (!el) continue;
-        if (el.getBoundingClientRect().top <= 110) current = id;
-      }
-      setActiveNav(current);
-    };
-    onScroll();
-    window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
+    const elements = ids
+      .map((id) => document.getElementById(id))
+      .filter((el): el is HTMLElement => Boolean(el));
+    if (!elements.length) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((e) => e.isIntersecting)
+          .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+        const id = visible[0]?.target.id;
+        if (id) setActiveNav(id);
+      },
+      { rootMargin: '-20% 0px -60% 0px', threshold: [0, 0.25, 0.5] },
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    return () => observer.disconnect();
   }, []);
 
   return (
-    <InstPageShell>
-      <InstFamilyNav active="institutions" className="sticky top-0 z-40" />
-      <header className="border-b border-neutral-200 bg-[#f7f6f3]">
-        <InstContainer className="py-14 sm:py-20 md:py-24">
-          <InstSectionLabel>{H.hero.eyebrow}</InstSectionLabel>
-          <h1 className="max-w-4xl font-['MoMA_Sans'] text-3xl font-semibold leading-[1.12] tracking-tight sm:text-4xl md:text-5xl">
-            {H.hero.headline}
-          </h1>
-          <p className="mt-5 max-w-2xl text-base leading-relaxed text-neutral-700 sm:text-lg">
-            {H.hero.lead}
-          </p>
-          <p className="mt-4 max-w-2xl text-sm leading-relaxed text-neutral-600">
-            {H.hero.availability}
-          </p>
-          <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
-            <InstPrimaryCta
-              href={H.hero.primaryCta.href}
-              label={H.hero.primaryCta.label}
-              external={H.hero.primaryCta.external}
-              onClick={() =>
-                track('cta_institutions_click', { source: 'institutions_hero' })
-              }
-            />
-            <InstSecondaryCta
-              href={H.hero.secondaryCta.href}
-              label={H.hero.secondaryCta.label}
-              external={H.hero.secondaryCta.external}
-            />
-          </div>
-          <dl className="mt-10 grid max-w-xl grid-cols-3 gap-4 border-t border-neutral-200 pt-8">
-            <div>
-              <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
-                Organizations
-              </dt>
-              <dd className="mt-1 font-['MoMA_Sans'] text-2xl font-semibold">{H.organizations.length}</dd>
-            </div>
-            <div>
-              <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
-                Case studies
-              </dt>
-              <dd className="mt-1 font-['MoMA_Sans'] text-2xl font-semibold">{H.caseStudies.length}</dd>
-            </div>
-            <div>
-              <dt className="font-mono text-[10px] uppercase tracking-[0.14em] text-neutral-500">
-                Practice lanes
-              </dt>
-              <dd className="mt-1 font-['MoMA_Sans'] text-2xl font-semibold">{H.lanes.length}</dd>
-            </div>
-          </dl>
-        </InstContainer>
-      </header>
+    <InstPageShell className="pt-[192px]">
+      <a
+        href="#top"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:bg-white focus:px-3 focus:py-2"
+      >
+        Skip to institutions overview
+      </a>
+      <OpportunityApplicationBanner banner={H.banner} className="mb-0" />
+      {H.bannerNote ? (
+        <p className="border-b border-neutral-200 bg-amber-50/80 px-4 py-2 text-center font-mono text-[10px] uppercase tracking-[0.14em] text-amber-950 sm:px-6">
+          {H.bannerNote}
+        </p>
+      ) : null}
 
-      <InstContainer className="py-8 sm:py-10">
-        <ProposePilotBand />
-      </InstContainer>
+      <InstFamilyNav active="institutions" className="sticky top-0 z-40" />
 
       <nav
         className="sticky top-[45px] z-30 border-b border-neutral-200 bg-[#f7f6f3]/90 backdrop-blur"
         aria-label="Page sections"
       >
-        <InstContainer className="flex gap-1.5 overflow-x-auto py-2 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-          {H.nav.map((item) => {
-            const active = activeNav === item.id;
-            const accentKey = SECTION_ACCENT[item.id as keyof typeof SECTION_ACCENT] ?? 'ink';
-            const accent = INST_ACCENT[accentKey];
-            return (
-              <a
-                key={item.id}
-                href={`#${item.id}`}
-                className={cn(
-                  'shrink-0 border px-3 py-1.5 text-xs font-medium transition',
-                  active ? accent.chipActive : accent.chip,
-                )}
-                onClick={(e) => {
-                  e.preventDefault();
-                  scrollToId(item.id);
-                  setActiveNav(item.id);
-                }}
-              >
-                {item.label}
-              </a>
-            );
-          })}
-        </InstContainer>
-      </nav>
-
-      <section
-        id="practice"
-        className="scroll-mt-28 border-b border-neutral-200 py-14 sm:py-16"
-        aria-labelledby="lanes-heading"
-      >
-        <InstContainer>
-          <InstReveal>
-            <InstSectionLabel accent="teal">What I build with institutions</InstSectionLabel>
-            <h2 id="lanes-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
-              Four lanes of institutional practice
-            </h2>
-          </InstReveal>
-          <ul className="mt-10 grid gap-4 sm:grid-cols-2">
-            {H.lanes.map((lane, index) => {
-              const accentKey = lane.accent ?? 'ink';
-              const accent = INST_ACCENT[accentKey];
+        <InstContainer className="flex items-center gap-2 py-2">
+          <div className="flex min-w-0 flex-1 gap-1.5 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+            {H.nav.map((item) => {
+              const active = activeNav === item.id;
               return (
-                <InstReveal key={lane.id} delay={0.05 * index}>
-                  <li
-                    className={cn(
-                      'h-full border border-neutral-200 bg-white p-5 transition sm:p-6',
-                      'hover:ring-2',
-                      accent.ring,
-                    )}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      {lane.icon ? (
-                        <InstLaneIcon name={lane.icon} accent={accentKey} />
-                      ) : null}
-                      <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-neutral-500">
-                        {String(index + 1).padStart(2, '0')}
-                      </p>
-                    </div>
-                    <h3 className="mt-4 font-['MoMA_Sans'] text-lg font-semibold leading-snug">
-                      {lane.title}
-                    </h3>
-                    <p className="mt-3 text-sm leading-relaxed text-neutral-700">{lane.body}</p>
-                    <Link
-                      href={lane.href}
-                      className={cn(
-                        'mt-5 inline-flex min-h-10 items-center gap-1.5 text-sm font-semibold underline-offset-4 hover:underline',
-                        accent.text,
-                      )}
-                    >
-                      {lane.linkLabel}
-                      <ArrowRight className="h-3.5 w-3.5" aria-hidden />
-                    </Link>
-                  </li>
-                </InstReveal>
-              );
-            })}
-          </ul>
-        </InstContainer>
-      </section>
-
-      <section
-        id="case-studies"
-        className="scroll-mt-28 border-b border-neutral-200 py-14 sm:py-16"
-        aria-labelledby="case-studies-heading"
-      >
-        <InstContainer>
-          <InstReveal>
-            <InstSectionLabel>Evidence</InstSectionLabel>
-            <h2 id="case-studies-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
-              Case studies
-            </h2>
-            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-neutral-700 sm:text-base">
-              Flagship systems and programs first, then exhibition and festival proof. Each card links to a
-              dedicated page or archive on this site.
-            </p>
-          </InstReveal>
-
-          <ul className="mt-10 grid gap-6 md:grid-cols-2">
-            {featured.map((study, i) => (
-              <InstReveal key={study.id} delay={0.04 * i}>
-                <li>
-                  <CaseStudyCard study={study} large />
-                </li>
-              </InstReveal>
-            ))}
-          </ul>
-
-          <h3 className="mt-12 font-['MoMA_Sans'] text-xl font-semibold sm:text-2xl">
-            More institutional evidence
-          </h3>
-          <ul className="mt-6 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-            {moreStudies.map((study, i) => (
-              <InstReveal key={study.id} delay={0.03 * i}>
-                <li>
-                  <CaseStudyCard study={study} />
-                </li>
-              </InstReveal>
-            ))}
-          </ul>
-        </InstContainer>
-      </section>
-
-      <section
-        id="organizations"
-        className="scroll-mt-28 border-b border-neutral-200 py-14 sm:py-16"
-        aria-labelledby="orgs-heading"
-      >
-        <InstContainer>
-          <InstReveal>
-            <InstSectionLabel accent="ocean">Directory</InstSectionLabel>
-            <h2 id="orgs-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
-              Organizations worked with
-            </h2>
-            <p className="mt-3 max-w-2xl text-sm leading-relaxed text-neutral-700 sm:text-base">
-              {H.organizations.length} verified institutions — filter by relationship type.
-            </p>
-          </InstReveal>
-
-          <div
-            className="mt-6 flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
-            role="group"
-            aria-label="Filter organizations"
-          >
-            {ORG_FILTERS.map((filter) => {
-              const active = orgFilter === filter.id;
-              return (
-                <button
-                  key={filter.id}
-                  type="button"
-                  aria-pressed={active}
-                  onClick={() => setOrgFilter(filter.id)}
+                <a
+                  key={item.id}
+                  href={`#${item.id}`}
                   className={cn(
-                    'shrink-0 border px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.12em] transition',
+                    'inline-flex min-h-11 shrink-0 items-center border-b-[3px] px-3 py-1.5 text-xs font-medium transition',
                     active
-                      ? INST_ACCENT.ocean.chipActive
-                      : 'border-neutral-300 bg-white text-neutral-700 hover:border-neutral-500',
+                      ? 'border-neutral-950 font-semibold text-neutral-950'
+                      : 'border-transparent text-neutral-600 hover:text-neutral-950',
+                    active && SECTION_ACCENT[item.id] === 'ocean' && 'border-sky-700',
+                    active && SECTION_ACCENT[item.id] === 'teal' && 'border-teal-700',
+                    active && SECTION_ACCENT[item.id] === 'copper' && 'border-amber-700',
+                    active && SECTION_ACCENT[item.id] === 'rose' && 'border-rose-700',
+                    active && SECTION_ACCENT[item.id] === 'violet' && 'border-violet-700',
                   )}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    scrollToId(item.id);
+                    setActiveNav(item.id);
+                  }}
                 >
-                  {filter.label}
-                </button>
+                  {item.label}
+                </a>
               );
             })}
           </div>
-
-          <ul className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {filteredOrgs.map((org, i) => (
-              <InstReveal key={org.id} delay={Math.min(0.03 * i, 0.24)}>
-                <li>
-                  <OrgCard org={org} />
-                </li>
-              </InstReveal>
-            ))}
-          </ul>
-
-          <p className="mt-8 max-w-3xl text-xs leading-relaxed text-neutral-500">{H.honestyNote}</p>
+          <a
+            href={H.hero.primaryCta.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hidden min-h-11 shrink-0 items-center gap-1.5 bg-neutral-950 px-3 py-1.5 text-xs font-semibold text-white sm:inline-flex"
+            onClick={() => track('institutions_cta_click', { placement: 'sticky-nav' })}
+          >
+            <CalendarDays className="h-3.5 w-3.5" aria-hidden />
+            Discuss a project
+          </a>
         </InstContainer>
-      </section>
+      </nav>
 
-      <section id="engage" className="scroll-mt-28 py-14 sm:py-16" aria-labelledby="next-heading">
-        <InstContainer>
-          <InstReveal>
-            <InstSectionLabel accent="copper">Engagements</InstSectionLabel>
-            <h2 id="next-heading" className="font-['MoMA_Sans'] text-2xl font-semibold sm:text-3xl">
-              {H.nextSteps.title}
-            </h2>
-            <ul className="mt-8 space-y-3">
-              {H.nextSteps.items.map((item) => (
-                <li
-                  key={item}
-                  className="border-l-2 border-amber-700 bg-amber-50/60 py-3 pl-4 text-sm leading-relaxed text-neutral-800 sm:text-base"
-                >
-                  {item}
-                </li>
-              ))}
-            </ul>
-            <div className="mt-10 flex flex-col gap-3 sm:flex-row">
-              <InstPrimaryCta
-                href={H.hero.primaryCta.href}
-                label={H.hero.primaryCta.label}
-                onClick={() =>
-                  track('cta_institutions_click', { source: 'institutions_footer' })
-                }
-              />
-              <InstSecondaryCta href="/oolite-arts" label="Start with Oolite proof" />
-            </div>
-          </InstReveal>
-        </InstContainer>
-      </section>
+      <InstitutionsHero />
+      <InstitutionalProofStrip />
+      <PracticeLaneGrid />
+      <CompoundingSystem />
+      <FlagshipCaseStudies />
+      <AdditionalEvidence />
+      <ProcessSteps />
+      <EngagementModes />
+      <InstitutionArchive />
+      <InstitutionsFinalCTA />
     </InstPageShell>
   );
 }

--- a/src/components/institutions/PracticeLaneGrid.tsx
+++ b/src/components/institutions/PracticeLaneGrid.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  ArrowRight,
+  Database,
+  FlaskConical,
+  RadioTower,
+  Workflow,
+  type LucideIcon,
+} from 'lucide-react';
+import { institutionsHub as H, type PracticeLaneAccent } from '@/content/institutions/hub';
+import { track } from '@/lib/analytics';
+import {
+  INST_ACCENT,
+  InstContainer,
+  InstReveal,
+  InstSectionLabel,
+  LANE_ACCENT,
+} from '@/components/institutions/InstitutionalUi';
+import { LaneStackVisual } from '@/components/institutions/IcaSystemsDiagram';
+import { cn } from '@/lib/utils';
+
+const LANE_ICON: Record<(typeof H.lanes)[number]['icon'], LucideIcon> = {
+  database: Database,
+  workflow: Workflow,
+  radio: RadioTower,
+  flask: FlaskConical,
+};
+
+const LANE_FLOW: Record<(typeof H.lanes)[number]['id'], string> = {
+  'web-salesforce': 'Salesforce → WordPress / ticketing → public site',
+  'automation-operations': 'Intake → Airtable / n8n → documented handoff',
+  'livestream-production': 'OBS → captions → YouTube / hybrid program',
+  'digital-labs-programs': 'Equipment → workshop / open lab → documentation',
+};
+
+export function PracticeLaneGrid() {
+  return (
+    <section
+      id="services"
+      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      aria-labelledby="lanes-heading"
+    >
+      <InstContainer>
+        <InstReveal>
+          <InstSectionLabel accent="ocean">Practice lanes</InstSectionLabel>
+          <h2 id="lanes-heading" className="font-['MoMA_Sans'] text-[clamp(1.75rem,3.5vw,3rem)] font-semibold">
+            Four ways to engage the systems behind the program
+          </h2>
+        </InstReveal>
+        <ul className="mt-10 grid gap-4 sm:grid-cols-2">
+          {H.lanes.map((lane, index) => {
+            const accentKey = LANE_ACCENT[lane.accent as PracticeLaneAccent];
+            const accent = INST_ACCENT[accentKey];
+            const Icon = LANE_ICON[lane.icon];
+            return (
+              <InstReveal key={lane.id} delay={0.05 * index}>
+                <li>
+                  <Link
+                    href={lane.href}
+                    id={lane.id}
+                    className={cn(
+                      'group flex h-full flex-col border border-neutral-200 bg-white p-5 transition sm:p-6',
+                      'hover:ring-2 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+                      accent.ring,
+                    )}
+                    onClick={() =>
+                      track('institutions_lane_select', { lane: lane.id })
+                    }
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <span
+                        className={cn(
+                          'inline-flex h-10 w-10 items-center justify-center',
+                          accent.iconBg,
+                        )}
+                        aria-hidden
+                      >
+                        <Icon className="h-5 w-5" strokeWidth={1.75} />
+                      </span>
+                      <p className="font-mono text-[11px] uppercase tracking-[0.16em] text-neutral-500">
+                        {lane.index}
+                      </p>
+                    </div>
+                    <h3 className="mt-4 font-['MoMA_Sans'] text-lg font-semibold leading-snug sm:text-xl">
+                      {lane.title}
+                    </h3>
+                    <p className="mt-3 text-sm leading-relaxed text-neutral-700">{lane.description}</p>
+                    <p
+                      className={cn(
+                        'mt-3 text-sm font-medium opacity-0 transition-opacity duration-200',
+                        'group-hover:opacity-100 group-focus-visible:opacity-100',
+                        'max-sm:opacity-100',
+                        accent.text,
+                      )}
+                    >
+                      What this solves: {lane.solves}
+                    </p>
+                    <LaneStackVisual logos={lane.stack} />
+                    <p className="mt-4 font-mono text-[10px] uppercase tracking-[0.12em] text-neutral-500">
+                      {LANE_FLOW[lane.id]}
+                    </p>
+                    <ul className="mt-4 flex flex-wrap gap-1.5">
+                      {lane.proofTags.map((tag) => (
+                        <li
+                          key={tag}
+                          className={cn(
+                            'border px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em]',
+                            accent.chip,
+                          )}
+                        >
+                          {tag}
+                        </li>
+                      ))}
+                    </ul>
+                    <span className={cn('mt-5 inline-flex items-center gap-1.5 text-sm font-semibold', accent.text)}>
+                      {lane.linkLabel}
+                      <ArrowRight className="h-3.5 w-3.5 transition group-hover:translate-x-0.5" aria-hidden />
+                    </span>
+                  </Link>
+                </li>
+              </InstReveal>
+            );
+          })}
+        </ul>
+      </InstContainer>
+    </section>
+  );
+}

--- a/src/content/evidence/applicationBanners.ts
+++ b/src/content/evidence/applicationBanners.ts
@@ -172,6 +172,18 @@ export const artistInfrastructureBanner = defineApplicationBanner({
   frameClass: FLAGSHIP_BANNER_FRAME,
 });
 
+/**
+ * /institutions — cinematic lab still until a dedicated 2172×724 services banner is produced.
+ * Cover crop of the Oolite Digital Lab 360 room (institutional workspace, not a logo wall).
+ */
+export const institutionsDigitalSystemsBanner = defineApplicationBanner({
+  src: `${cdn}/v1786123448/oolite-arts/oolite-arts-digital-lab-360-photo_uaguwe.jpg`,
+  alt: 'Oolite Arts Digital Lab — workstations and production room used for artist programs',
+  intrinsicRatio: 16 / 9,
+  presentation: 'cover',
+  frameClass: FLAGSHIP_BANNER_FRAME,
+});
+
 /** Morley — Art Director (Remote, Florida). */
 export const morleyArtDirectorBanner = defineApplicationBanner({
   src: `${cdn}/v1785862415/jobs/banners/art-director-morley-banner_b5ridm.png`,

--- a/src/content/institutions/hub.ts
+++ b/src/content/institutions/hub.ts
@@ -1,5 +1,5 @@
 /**
- * /institutions — modular institutional portfolio hub.
+ * /institutions — institutional technology services page.
  * Organizations and case studies must match verified site/CV evidence.
  * Do not invent affiliations. Application-only orgs stay out of the worked-with list.
  */
@@ -10,13 +10,19 @@ import {
   OOLITE_DIGITAL_LAB_IMAGE_ALT,
   evidenceProjects,
 } from '@/content/evidence/projects';
+import { institutionsDigitalSystemsBanner } from '@/content/evidence/applicationBanners';
+import type { LogoBandItem } from '@/content/evidence/recruitingLogoBand';
+import type { OpportunityAudienceKeywords } from '@/content/opportunities/types';
+import { N8N_LOGO } from '@/constants/art-of-ai-agents';
+import { digilabAsset } from '@/content/oolite-arts/media';
 import {
-  INSTITUTIONAL_AVAILABILITY,
   INSTITUTIONAL_CALENDLY_URL,
-  type InstitutionalLane,
+  INSTITUTIONAL_EMAIL,
+  INSTITUTIONAL_SERVICES_AVAILABILITY,
 } from './shared';
 
 const CDN = 'https://res.cloudinary.com/dck5rzi4h/image/upload';
+const jobsCdn = CDN;
 const BAKEHOUSE_IMAGE = `${CDN}/v1717960571/art/moisestech-website/digitaldivinities-moisesdsanabria-fabiolalarios-bakehouse-openstudios-spring-2024_f3ahbx.jpg`;
 const BAKEHOUSE_STUDIO = `${CDN}/v1783907488/art/moisestech-website/studio/moises-sanabria-open-studios-red-world-eye-2024_zdyayj.jpg`;
 const LOCUST_IMAGE =
@@ -27,6 +33,7 @@ const MOMUS = `${CDN}/v1740950484/art/moisestech-website/exhibitions/apr_2025_te
 const ICA_NOTIONS = `${CDN}/v1739483923/art/moisestech-website/exhibitions/dec_2024_dminti_notions_of_home/NotionsOfHome_banner_soubxf.jpg`;
 const TRANSMEDIALE = `${CDN}/v1739483432/art/moisestech-website/exhibitions/oct_2024_post_masters_low_resolution/oct_2024_post_masters_low_resolution_poster_utzgio.png`;
 const AFIRME = `${CDN}/v1751123479/art/moisestech-website/exhibitions/june_2025_algoritmica_intima_cdmx/algoritmica-intima-exhibitions-june-2025_zmg4mq.jpg`;
+const N8N_DIAGRAM = `${CDN}/v1786386766/dccmiami/workshops/the-art-of-ai-agents/n8n-diagram-email-inbox-organizer_nqwn9r.png`;
 const DCC = evidenceProjects['digital-culture-infrastructure'];
 
 export type OrgRelationship =
@@ -51,6 +58,8 @@ export type InstitutionOrg = {
   external?: boolean;
   imageSrc?: string;
   imageAlt?: string;
+  /** Shown in the compact archive before “View full experience”. */
+  archiveFeatured?: boolean;
 };
 
 export type InstitutionCaseStudy = {
@@ -67,134 +76,444 @@ export type InstitutionCaseStudy = {
   featured?: boolean;
 };
 
+export type PracticeLaneId =
+  | 'web-salesforce'
+  | 'automation-operations'
+  | 'livestream-production'
+  | 'digital-labs-programs';
+
+export type PracticeLaneAccent = 'web' | 'automation' | 'live' | 'lab';
+
+export type PracticeLane = {
+  id: PracticeLaneId;
+  index: string;
+  title: string;
+  description: string;
+  solves: string;
+  href: string;
+  linkLabel: string;
+  accent: PracticeLaneAccent;
+  icon: 'database' | 'workflow' | 'radio' | 'flask';
+  proofTags: string[];
+  stack: LogoBandItem[];
+};
+
 export const ORG_RELATIONSHIP_LABELS: Record<OrgRelationship, string> = {
-  lab: 'Lab operations',
-  residency: 'Studio residency',
+  lab: 'Employment · Lab operations',
+  residency: 'Residency',
   employment: 'Employment',
   exhibition: 'Exhibition',
-  workshop: 'Workshop / teaching',
-  platform: 'Platform build',
-  funder: 'Funder',
-  education: 'Education partner',
-  festival: 'Festival host',
+  workshop: 'Teaching / workshop',
+  platform: 'Platform',
+  funder: 'Funder context',
+  education: 'Education',
+  festival: 'Exhibition / festival',
+};
+
+const STACK = {
+  salesforce: {
+    src: 'https://cdn.simpleicons.org/salesforce/00A1E0',
+    alt: 'Salesforce',
+    height: 28,
+  },
+  wordpress: {
+    src: 'https://cdn.simpleicons.org/wordpress/21759B',
+    alt: 'WordPress',
+    height: 28,
+  },
+  bloomerang: {
+    src: '/images/tech-logos/bloomerang.svg',
+    alt: 'Bloomerang',
+    height: 28,
+  },
+  airtable: {
+    src: `${jobsCdn}/v1783032752/jobs/airtable_logo_xserwf.png`,
+    alt: 'Airtable',
+    height: 28,
+  },
+  n8n: { src: N8N_LOGO.src, alt: N8N_LOGO.alt, height: 28 },
+  obs: {
+    src: 'https://cdn.simpleicons.org/obsstudio/302E31',
+    alt: 'OBS Studio',
+    height: 28,
+  },
+  aws: { src: '/images/tech-logos/aws.svg', alt: 'AWS', height: 28 },
+  github: { src: '/images/tech-logos/github.svg', alt: 'GitHub', height: 28 },
+} as const satisfies Record<string, LogoBandItem>;
+
+export const institutionsLogoBand: LogoBandItem[] = [
+  STACK.salesforce,
+  STACK.wordpress,
+  STACK.bloomerang,
+  STACK.airtable,
+  STACK.n8n,
+  STACK.obs,
+  STACK.aws,
+  STACK.github,
+  { src: 'https://cdn.simpleicons.org/zoom/2D8CFF', alt: 'Zoom', height: 36 },
+  { src: 'https://cdn.simpleicons.org/youtube/FF0000', alt: 'YouTube', height: 36 },
+];
+
+export const institutionsAudienceKeywords: OpportunityAudienceKeywords = {
+  lead: 'I work inside the software cultural organizations already use—',
+  terms: [
+    {
+      label: 'Salesforce',
+      detail: 'Collection data, membership, registration, and reporting connected to public web systems.',
+    },
+    {
+      label: 'web support',
+      detail: 'WordPress, CMS, SEO, forms, and site maintenance without a new vendor for every update.',
+    },
+    {
+      label: 'automation',
+      detail: 'Intake, booking, communications, and documentation with human review and handoff.',
+    },
+    {
+      label: 'livestreaming',
+      detail: 'OBS production, captions, hybrid events, and reusable media workflows for public programs.',
+    },
+  ],
 };
 
 export const institutionsHub = {
   meta: {
-    title: 'Institutions — Artist-Centered Digital Systems | Moises Sanabria',
+    title: 'Digital Systems for Arts Institutions — Moises Sanabria',
     description:
-      'Organizations and case studies from Moises Sanabria’s institutional practice: Oolite Arts Digital Lab, Bakehouse Art Complex, Locust Projects, ICA Miami, DCC Miami, and exhibition partners.',
+      'Moises Sanabria builds web, Salesforce, automation, livestreaming, and digital-lab systems for museums, arts organizations, and artist-facing programs.',
     url: 'https://moises.tech/institutions',
   },
+  banner: institutionsDigitalSystemsBanner,
+  bannerNote: null as string | null,
+  logoBand: institutionsLogoBand,
+  logoBandLabel: 'Institutional software and production tools',
+  audienceKeywords: institutionsAudienceKeywords,
+  profile: {
+    src: digilabAsset('portrait.moises').src,
+    alt: digilabAsset('portrait.moises').alt,
+    label: 'Profile',
+  },
   hero: {
-    eyebrow: 'Institutional practice',
-    headline: 'I build artist-centered digital systems, programs, and experiences.',
+    eyebrow: 'Institutional technology · Miami',
+    headline: 'Digital systems for museums, arts organizations, and artist-facing programs.',
     lead:
-      'Directory of verified organizations and case studies. For a single outreach link covering workshops, lab proof, and engagement formats, start at Creative infrastructure for artists.',
-    availability: INSTITUTIONAL_AVAILABILITY,
+      'I help cultural organizations improve the systems behind their public programs—from websites, Salesforce, and operational automation to livestreaming, digital production, and creative-technology labs.',
+    support:
+      'With previous experience inside ICA Miami and recent technical direction at Oolite Arts, I can step into existing institutional environments quickly, reduce vendor handoffs, and move focused projects from diagnosis to implementation.',
+    availability: INSTITUTIONAL_SERVICES_AVAILABILITY,
+    availabilityLabel: 'Currently available · project-based + fractional engagements',
     primaryCta: {
-      label: 'Creative infrastructure overview',
-      href: '/artist-infrastructure',
-      external: false,
-    },
-    secondaryCta: {
-      label: 'Start a planning call',
+      label: 'Discuss a project',
       href: INSTITUTIONAL_CALENDLY_URL,
       external: true,
     },
+    secondaryCta: {
+      label: 'View selected institutional work',
+      href: '#work',
+      external: false,
+    },
+    collage: {
+      main: {
+        src: OOLITE_DIGITAL_LAB_IMAGE,
+        alt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
+        caption: 'Oolite Digital Lab — operated environment for artist programs.',
+      },
+      teaching: {
+        src: digilabAsset('workshop.art-tech-coding').src,
+        alt: digilabAsset('workshop.art-tech-coding').alt,
+        caption: 'Creative-coding workshop in use.',
+      },
+      workflow: {
+        src: N8N_DIAGRAM,
+        alt: 'n8n workflow diagram for an email inbox organizer used in artist automation teaching',
+        caption: 'Automation workflow — human review built in.',
+      },
+      captionCard: 'ICA Miami · Digital Producer · 2019–2020',
+    },
   },
   nav: [
-    { id: 'practice', label: 'Practice' },
-    { id: 'case-studies', label: 'Case studies' },
-    { id: 'organizations', label: 'Organizations' },
+    { id: 'top', label: 'Overview' },
+    { id: 'services', label: 'Services' },
+    { id: 'system', label: 'System' },
+    { id: 'work', label: 'Selected work' },
+    { id: 'evidence', label: 'Evidence' },
     { id: 'engage', label: 'Engage' },
+    { id: 'archive', label: 'Experience' },
   ],
+  proof: {
+    eyebrow: 'Institutional context',
+    items: [
+      {
+        id: 'ica',
+        name: 'ICA Miami',
+        role: 'Digital Producer',
+        dates: '2019–2020',
+        accent: 'web' as PracticeLaneAccent,
+        href: '/ica-miami',
+      },
+      {
+        id: 'oolite',
+        name: 'Oolite Arts',
+        role: 'Technical Director of Digital',
+        dates: '2025–2026',
+        accent: 'lab' as PracticeLaneAccent,
+        href: '/oolite-arts',
+      },
+      {
+        id: 'bakehouse',
+        name: 'Bakehouse Art Complex',
+        role: 'Studio 43 · institutional systems',
+        dates: 'Active',
+        accent: 'automation' as PracticeLaneAccent,
+        href: '/bakehouse',
+      },
+      {
+        id: 'ai24',
+        name: 'AI24 / DCC Miami',
+        role: 'Artist-owned cultural-technology practice',
+        dates: 'Ongoing',
+        accent: 'live' as PracticeLaneAccent,
+        href: 'https://dcc.miami',
+        external: true,
+      },
+    ],
+  },
   lanes: [
     {
-      id: 'embedded-leadership',
-      title: 'Embedded digital and creative-technology leadership',
-      body: 'Fractional or term-based roles that connect labs, screens, documentation, and artist support into one coherent institutional system—not isolated projects.',
+      id: 'web-salesforce',
+      index: '01',
+      title: 'Web and Salesforce systems',
+      description:
+        'Website management, CMS support, Salesforce integrations, registration and membership workflows, forms, analytics, search, and SEO.',
+      solves: 'Keeps public sites, CRM data, and registration in one maintainable system.',
+      href: '#work-ica',
+      linkLabel: 'ICA systems case study',
+      accent: 'web',
+      icon: 'database',
+      proofTags: ['ICA Miami', 'WordPress', 'Salesforce', 'GraphQL', 'AWS CloudFront', 'Registration'],
+      stack: [STACK.salesforce, STACK.wordpress, STACK.bloomerang, STACK.aws],
+    },
+    {
+      id: 'automation-operations',
+      index: '02',
+      title: 'Automation and digital operations',
+      description:
+        'Reporting, intake, booking, communications, documentation, and repetitive administrative workflows designed with human review and handoff.',
+      solves: 'Removes repetitive handoffs so staff time goes back to programs.',
+      href: '#work-bakehouse',
+      linkLabel: 'Bakehouse systems',
+      accent: 'automation',
+      icon: 'workflow',
+      proofTags: ['Airtable', 'n8n / Make', 'APIs', 'Structured outputs', 'Documentation'],
+      stack: [STACK.airtable, STACK.n8n],
+    },
+    {
+      id: 'livestream-production',
+      index: '03',
+      title: 'Livestreaming and digital production',
+      description:
+        'Public programs, member events, webinars, OBS production, captioning, hybrid events, and reusable media workflows.',
+      solves: 'Makes public programs reach remote audiences without a new vendor every time.',
+      href: '#work-ica',
+      linkLabel: 'ICA digital production',
+      accent: 'live',
+      icon: 'radio',
+      proofTags: ['ICA Miami Channel', 'OBS', 'Zoom webinars', 'Captions', 'YouTube', 'After Effects'],
+      stack: [STACK.obs],
+    },
+    {
+      id: 'digital-labs-programs',
+      index: '04',
+      title: 'Digital labs and artist programs',
+      description:
+        'Technical infrastructure, equipment planning, fabrication workflows, workshops, documentation, and artist support.',
+      solves: 'Turns a room of tools into an artist-facing program that staff can keep running.',
+      href: '#work-oolite',
+      linkLabel: 'Oolite Digital Lab',
+      accent: 'lab',
+      icon: 'flask',
+      proofTags: ['Oolite Arts', '3D printing', '3D scanning', 'VR', 'Laser cutting', 'Creative coding'],
+      stack: [],
+    },
+  ] satisfies PracticeLane[],
+  system: {
+    eyebrow: 'Operating method',
+    title: 'Need → system → use → evidence → continued capacity',
+    caption:
+      'The deliverable is not only the tool. It is the organization’s ability to keep using it.',
+    callout:
+      'At Oolite, equipment, workshops, open-lab support, documentation, and artist access operated as one connected program. That same logic can be adapted to web systems, Salesforce workflows, public media, or institutional AI.',
+    steps: [
+      {
+        id: 'listen',
+        title: 'Listen',
+        body: 'Map institutional, staff, artist, and audience needs.',
+      },
+      {
+        id: 'connect',
+        title: 'Connect',
+        body: 'Align existing space, software, hardware, and people.',
+      },
+      {
+        id: 'build',
+        title: 'Build',
+        body: 'Ship a workflow, platform, program, or production system.',
+      },
+      {
+        id: 'adopt',
+        title: 'Adopt',
+        body: 'Support staff and artists through use, teaching, and iteration.',
+      },
+      {
+        id: 'document',
+        title: 'Document',
+        body: 'Leave reusable systems and institutional memory.',
+      },
+    ],
+  },
+  flagship: [
+    {
+      id: 'oolite',
+      slug: 'oolite-arts',
+      institution: 'Oolite Arts',
+      headline: 'From a room of tools to an artist-facing digital program.',
+      role: 'Technical Director of Digital',
+      dates: '2025–2026',
+      statusLabel: 'Operated / delivered',
+      status: 'operated' as const,
+      primaryLane: 'lab' as PracticeLaneAccent,
+      summary:
+        'Technical direction connecting lab infrastructure, operations, booking, workshops, fabrication, vendors, and documentation into one artist-facing program.',
+      proofSequence: [
+        { stage: 'Need', text: 'A new lab, tools, and an artist-support mandate.' },
+        {
+          stage: 'Intervention',
+          text: 'Layout, equipment and software readiness, workshops, open lab, vendor coordination, fabrication workflows, documentation.',
+        },
+        {
+          stage: 'Adoption',
+          text: 'Published open-lab days, English and Spanish support, workshops, consultations, and return visits.',
+        },
+        {
+          stage: 'Capacity',
+          text: 'Documented workflows and a reusable institutional model.',
+        },
+      ],
+      facts: [
+        { value: 'Tue / Thu', label: 'Published open-lab days', verification: 'public' as const },
+        { value: '10–5', label: 'Published hours', verification: 'public' as const },
+        { value: 'EN / ES', label: 'Language support', verification: 'public' as const },
+        { value: '10', label: 'Artist Website workshop capacity', verification: 'public' as const },
+        { value: '8', label: 'Resin workshop capacity', verification: 'public' as const },
+      ],
+      media: [
+        {
+          src: OOLITE_DIGITAL_LAB_IMAGE,
+          alt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
+        },
+        {
+          src: digilabAsset('workshop.art-tech-coding').src,
+          alt: digilabAsset('workshop.art-tech-coding').alt,
+        },
+        {
+          src: digilabAsset('workshop.resin-2026').src,
+          alt: digilabAsset('workshop.resin-2026').alt,
+        },
+      ],
       href: '/oolite-arts',
-      linkLabel: 'Oolite Arts case study',
-      icon: 'leadership',
-      accent: 'teal',
+      cta: 'Open Oolite case study',
     },
     {
-      id: 'artist-pd',
-      title: 'Artist professional-development programs',
-      body: 'Workshops, mentorship infrastructure, and career-stage resources designed for artists—operations, capacity, and craft together.',
-      href: '/workshops',
-      linkLabel: 'Bookable workshops',
-      icon: 'programs',
-      accent: 'ocean',
+      id: 'ica',
+      slug: 'ica-miami',
+      institution: 'ICA Miami',
+      headline: 'Connecting museum data, public programming, and digital audiences.',
+      role: 'Digital Producer',
+      dates: 'October 2019–December 2020',
+      statusLabel: 'Employment / operated',
+      status: 'operated' as const,
+      primaryLane: 'web' as PracticeLaneAccent,
+      summary:
+        'Salesforce-to-WordPress workflows, ticketing, website management, livestreaming, interactive video, cloud infrastructure, SEO, and vendor coordination.',
+      proofSequence: [
+        {
+          stage: 'Need',
+          text: 'Digital autonomy, faster updates, connected collection and program data, remote programs.',
+        },
+        {
+          stage: 'Intervention',
+          text: 'Web and data integration, vendor coordination, streaming workflows, captioning, forms, reporting, and production.',
+        },
+        {
+          stage: 'Adoption',
+          text: 'Cross-department use across development, external affairs, education, curatorial, and programs.',
+        },
+        {
+          stage: 'Capacity',
+          text: 'Lower vendor friction and reusable public-program workflows.',
+        },
+      ],
+      facts: [
+        { value: 'Salesforce', label: 'Collection data → WordPress / ticketing', verification: 'public' as const },
+        { value: 'WordPress', label: 'Site management, GitHub, GraphQL, CloudFront', verification: 'public' as const },
+        { value: 'OBS', label: 'Livestreaming, YouTube, captions, After Effects', verification: 'public' as const },
+      ],
+      media: [],
+      href: '/ica-miami',
+      cta: 'Open ICA systems case study',
+      diagram: true,
     },
     {
-      id: 'platforms',
-      title: 'Institutional platforms, kiosks, and workflows',
-      body: 'SmartSigns, kiosk infrastructure, content systems, and proposed artist portals that make buildings and programs legible.',
+      id: 'bakehouse',
+      slug: 'bakehouse',
+      institution: 'Bakehouse Art Complex',
+      headline: 'Building artist-owned infrastructure inside an existing creative community.',
+      role: 'Studio 43 resident · institutional systems',
+      dates: 'Ongoing',
+      statusLabel: 'Mixed — labeled by module',
+      status: 'active' as const,
+      primaryLane: 'automation' as PracticeLaneAccent,
+      summary:
+        'SmartSigns, kiosk infrastructure, artist-facing systems, and portal planning—with shipped work separated from proposed work.',
+      proofSequence: [
+        {
+          stage: 'Need',
+          text: 'Make artist and program activity visible without recurring ad-hoc file drops.',
+        },
+        {
+          stage: 'Intervention',
+          text: 'Reusable vertical display formats, device and content workflow, portal and governance planning.',
+        },
+        {
+          stage: 'Adoption',
+          text: 'Active operational coordination and handoff in progress.',
+        },
+        {
+          stage: 'Capacity',
+          text: 'A future shared content model across screens, portal, programs, and staff workflows.',
+        },
+      ],
+      facts: [
+        { value: 'Shipped', label: 'SmartSigns + Raspberry Pi / Anthias displays', verification: 'public' as const },
+        { value: 'Proposed', label: 'Artist Portal on Assembly', verification: 'public' as const },
+        { value: 'Future', label: 'Connected digital lab and communications partnership', verification: 'public' as const },
+      ],
+      modules: [
+        { status: 'shipped' as const, label: 'Shipped / active implementation', text: 'SmartSigns and Raspberry Pi / Anthias display infrastructure.' },
+        { status: 'proposed' as const, label: 'Proposed', text: 'Artist Portal on Assembly.' },
+        { status: 'proposed' as const, label: 'Future opportunity', text: 'Connected digital lab, communications, and programming partnership.' },
+      ],
+      media: [
+        {
+          src: BAKEHOUSE_IMAGE,
+          alt: 'Bakehouse Art Complex — open studios and public-facing cultural context',
+        },
+      ],
       href: '/bakehouse',
-      linkLabel: 'Bakehouse digital systems',
-      icon: 'platforms',
-      accent: 'copper',
+      cta: 'Open Bakehouse systems case study',
     },
-    {
-      id: 'prototypes',
-      title: 'Creative-technology prototypes and public experiences',
-      body: 'Fabrication workflows, public installations, and educational toolkits that move from lab experiment to shared institutional capacity.',
-      href: '/ai24',
-      linkLabel: 'AI24 studio',
-      icon: 'prototypes',
-      accent: 'ink',
-    },
-  ] satisfies InstitutionalLane[],
-  caseStudies: [
-    {
-      id: 'oolite-digital-lab',
-      title: 'Oolite Arts Digital Lab',
-      org: 'Oolite Arts',
-      kind: 'systems',
-      kindLabel: 'Systems · Lab ops',
-      body: 'Technical direction turning space, tools, curriculum, documentation, and sustained artist support into an accessible creative-technology program.',
-      href: '/oolite-arts',
-      imageSrc: OOLITE_DIGITAL_LAB_IMAGE,
-      imageAlt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
-      featured: true,
-    },
-    {
-      id: 'bakehouse-systems',
-      title: 'Bakehouse digital systems',
-      org: 'Bakehouse Art Complex',
-      kind: 'systems',
-      kindLabel: 'Systems · Screens',
-      body: 'Shipped SmartSigns and Raspberry Pi / Anthias kiosk infrastructure; Artist Portal proposed on Assembly; connected institutional communications next.',
-      href: '/bakehouse',
-      imageSrc: BAKEHOUSE_IMAGE,
-      imageAlt: 'Bakehouse Art Complex — open studios and public-facing cultural context',
-      featured: true,
-    },
-    {
-      id: 'smartsign',
-      title: 'SmartSign institutional display',
-      org: 'Bakehouse · Infra24',
-      kind: 'platform',
-      kindLabel: 'Platform',
-      body: 'Repeatable vertical display formats for artists, events, and studio activity—service and workshop surface for institutional screens.',
-      href: '/services/smartsign',
-      imageSrc: BAKEHOUSE_STUDIO,
-      imageAlt: 'Bakehouse studio context for public-facing screen systems',
-    },
-    {
-      id: 'dcc-miami',
-      title: 'Digital Culture Center Miami',
-      org: 'DCC Miami',
-      kind: 'platform',
-      kindLabel: 'Platform',
-      body: DCC.summary,
-      href: DCC.href ?? 'https://dcc.miami',
-      external: true,
-      imageSrc: DCC.imageSrc,
-      imageAlt: DCC.imageAlt,
-    },
+  ],
+  additionalEvidence: [
     {
       id: 'locust-ai-agents',
       title: 'The Art of AI Agents',
@@ -205,7 +524,18 @@ export const institutionsHub = {
       href: '/workshop/the-art-of-ai-agents',
       imageSrc: LOCUST_IMAGE,
       imageAlt: 'The Art of AI Agents workshop at Locust Projects',
-      featured: true,
+    },
+    {
+      id: 'dcc-miami',
+      title: 'Digital Culture Center Miami',
+      org: 'DCC Miami',
+      kind: 'platform',
+      kindLabel: 'Platform',
+      body: 'Artist-owned cultural-technology practice—institutional platforms and the operating name for embedded Digital Lab partnerships.',
+      href: DCC.href ?? 'https://dcc.miami',
+      external: true,
+      imageSrc: DCC.imageSrc,
+      imageAlt: DCC.imageAlt,
     },
     {
       id: 'ai24-studio',
@@ -219,17 +549,6 @@ export const institutionsHub = {
       imageAlt: 'AI24 website — program and product hub',
     },
     {
-      id: 'ica-employment',
-      title: 'ICA Miami — digital production',
-      org: 'Institute of Contemporary Art, Miami',
-      kind: 'program',
-      kindLabel: 'Employment · Exhibition',
-      body: 'Digital Producer (2019–2020) plus later exhibition contexts including Notions of Home (ICA × Dminti).',
-      href: '/cv',
-      imageSrc: ICA_NOTIONS,
-      imageAlt: 'Notions of Home — ICA Miami × Dminti exhibition banner',
-    },
-    {
       id: 'munag-continuum',
       title: 'CONTINUUM — Smart Shoppers',
       org: 'MUNAG · Fundación Paiz',
@@ -239,28 +558,6 @@ export const institutionsHub = {
       href: '/art/smart-shoppers',
       imageSrc: SMART_SHOPPERS,
       imageAlt: 'Smart Shoppers — CONTINUUM exhibition work',
-    },
-    {
-      id: 'museum-of-sex',
-      title: 'Taste the Algorithm',
-      org: 'Museum of Sex Miami',
-      kind: 'exhibition',
-      kindLabel: 'Exhibition',
-      body: 'F*ck Art: Nature & Artifice — Miami exhibition examining ecology, technology, and mediated desire.',
-      href: '/ai24',
-      imageSrc: TRANSMEDIALE,
-      imageAlt: 'Exhibition context for Taste the Algorithm / related screening materials',
-    },
-    {
-      id: 'momus-technofetishism',
-      title: 'Technofetishism',
-      org: 'MOMus — Thessaloniki',
-      kind: 'exhibition',
-      kindLabel: 'Exhibition',
-      body: 'International exhibition at MOMus Experimental Center for the Arts.',
-      href: '/calendar/exhibitions',
-      imageSrc: MOMUS,
-      imageAlt: 'MOMus Technofetishism exhibition banner',
     },
     {
       id: 'chroma-touch-grass',
@@ -274,17 +571,112 @@ export const institutionsHub = {
       imageAlt: 'Doomscrolling Treadmill / Touch Grass festival install',
     },
     {
-      id: 'algoritmica-intima',
-      title: 'Algoritmica Intima: Runtime',
-      org: 'Centro Cultural Afirme · CDMX',
+      id: 'momus-technofetishism',
+      title: 'Technofetishism',
+      org: 'MOMus — Thessaloniki',
       kind: 'exhibition',
       kindLabel: 'Exhibition',
-      body: 'Exhibition on algorithms, intimacy, and computational experience in Mexico City.',
+      body: 'International exhibition at MOMus Experimental Center for the Arts.',
       href: '/calendar/exhibitions',
-      imageSrc: AFIRME,
-      imageAlt: 'Algoritmica Intima exhibition, Centro Cultural Afirme',
+      imageSrc: MOMUS,
+      imageAlt: 'MOMus Technofetishism exhibition banner',
     },
   ] satisfies InstitutionCaseStudy[],
+  process: {
+    eyebrow: 'How work begins',
+    title: 'Review, then build, then leave it usable',
+    reassurance: [
+      'Works with existing tools',
+      'Human review for AI/automation',
+      'Clear shipped / proposed labeling',
+      'Documentation included',
+      'Scope and ownership defined',
+    ],
+    steps: [
+      {
+        id: 'review',
+        icon: 'search' as const,
+        title: 'Technical review',
+        body: 'Map tools, owners, handoffs, bottlenecks, permissions, and current costs. Define what should be repaired, automated, connected, or left alone.',
+      },
+      {
+        id: 'build',
+        icon: 'wrench' as const,
+        title: 'Build',
+        body: 'Deliver a focused implementation with clear scope, review gates, evidence, and practical staff involvement.',
+      },
+      {
+        id: 'support',
+        icon: 'layers' as const,
+        title: 'Support and handoff',
+        body: 'Document the system, train the people using it, measure adoption, and establish the next maintenance rhythm.',
+      },
+    ],
+  },
+  engagement: {
+    eyebrow: 'Start with the right scope',
+    title: 'Three ways to begin',
+    lead: 'Tell me what is slowing your team down.',
+    modes: [
+      {
+        id: 'review',
+        title: 'Technical review',
+        duration: '2–4 weeks',
+        outcome:
+          'System map, bottleneck analysis, risk list, prioritized roadmap, and implementation options.',
+        bestFor:
+          'Institutions unsure whether the problem is the website, CRM, workflow, vendor structure, or ownership.',
+        icon: 'search' as const,
+      },
+      {
+        id: 'project',
+        title: 'Focused project',
+        duration: '4–12 weeks',
+        outcome:
+          'One clearly defined system, integration, workflow, public program, or technical production setup—shipped and documented.',
+        bestFor: 'A known bottleneck with a bounded owner and a shippable artifact.',
+        icon: 'wrench' as const,
+      },
+      {
+        id: 'fractional',
+        title: 'Fractional support',
+        duration: 'Monthly / term-based',
+        outcome:
+          'Ongoing webmaster, automation, digital production, or technical leadership embedded alongside staff and vendors.',
+        bestFor: 'Teams that need continuity without a full-time hire or another vendor handoff.',
+        icon: 'layers' as const,
+      },
+    ],
+    primaryCta: {
+      label: 'Schedule a 20-minute conversation',
+      href: INSTITUTIONAL_CALENDLY_URL,
+    },
+    secondaryCta: {
+      label: 'Email Moises',
+      href: `mailto:${INSTITUTIONAL_EMAIL}`,
+    },
+  },
+  contact: {
+    headline:
+      'A website problem is often a workflow problem. A workflow problem is often an ownership problem. Let’s map the system.',
+    body: 'I am currently available for focused projects, technical reviews, institutional workshops, and fractional digital support in Miami and remotely.',
+    image: {
+      src: digilabAsset('portrait.moises').src,
+      alt: digilabAsset('portrait.moises').alt,
+    },
+    cvHref: '/cv/tech',
+    email: INSTITUTIONAL_EMAIL,
+  },
+  artBand: {
+    title: 'Cultural judgment is part of the technical work.',
+    body: 'My artistic practice keeps the systems work accountable to the cultural questions institutions actually hold: authorship, attention, labor, access, value, and the public meaning of technology.',
+    items: [
+      { src: SMART_SHOPPERS, alt: 'Smart Shoppers sculpture', href: '/art/smart-shoppers', label: 'Smart Shoppers / CONTINUUM · MUNAG' },
+      { src: TOUCH_GRASS, alt: 'Touch Grass / Doomscrolling installation', href: '/art/doomscrolling_treadmill', label: 'Touch Grass · Chroma / Superblue' },
+      { src: MOMUS, alt: 'Technofetishism at MOMus', href: '/calendar/exhibitions', label: 'Technofetishism · MOMus' },
+      { src: AFIRME, alt: 'Algoritmica Intima exhibition', href: '/calendar/exhibitions', label: 'Algoritmica Intima · Mexico City' },
+    ],
+  },
   organizations: [
     {
       id: 'oolite',
@@ -293,22 +685,34 @@ export const institutionsHub = {
       relationship: 'lab',
       relationshipLabel: ORG_RELATIONSHIP_LABELS.lab,
       summary:
-        'With Director of Digital Lab Fabiola Larios; Technical Director of Digital Moises Sanabria — Knight-supported Digital Lab: workshops, fabrication, documentation, and artist support.',
+        'Technical Director of Digital — Knight-supported Digital Lab: workshops, fabrication, documentation, and artist support. With Director of Digital Lab Fabiola Larios.',
       href: '/oolite-arts',
       imageSrc: OOLITE_DIGITAL_LAB_IMAGE,
       imageAlt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
+      archiveFeatured: true,
+    },
+    {
+      id: 'ica',
+      name: 'Institute of Contemporary Art, Miami',
+      location: 'Miami, FL',
+      relationship: 'employment',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.employment,
+      summary: 'Digital Producer (2019–2020): Salesforce–WordPress workflows, website management, livestreaming, SEO, and vendor coordination.',
+      href: '/ica-miami',
+      archiveFeatured: true,
     },
     {
       id: 'bakehouse',
       name: 'Bakehouse Art Complex',
       location: 'Miami, FL',
       relationship: 'residency',
-      relationshipLabel: 'Studio residency · Systems',
+      relationshipLabel: 'Residency · institutional systems',
       summary:
         'Studio 43 residency; SmartSigns / Anthias display systems; open studios; proposed Artist Portal on Assembly.',
       href: '/bakehouse',
       imageSrc: BAKEHOUSE_STUDIO,
       imageAlt: 'Bakehouse Art Complex — Studio 43 and open studios context',
+      archiveFeatured: true,
     },
     {
       id: 'locust',
@@ -320,17 +724,7 @@ export const institutionsHub = {
       href: '/workshop/the-art-of-ai-agents',
       imageSrc: LOCUST_IMAGE,
       imageAlt: 'Workshop at Locust Projects',
-    },
-    {
-      id: 'ica',
-      name: 'Institute of Contemporary Art, Miami',
-      location: 'Miami, FL',
-      relationship: 'employment',
-      relationshipLabel: 'Employment · Exhibition',
-      summary: 'Digital Producer (2019–2020); later exhibition contexts including Notions of Home.',
-      href: '/cv',
-      imageSrc: ICA_NOTIONS,
-      imageAlt: 'ICA Miami exhibition context',
+      archiveFeatured: true,
     },
     {
       id: 'dcc',
@@ -339,22 +733,12 @@ export const institutionsHub = {
       relationship: 'platform',
       relationshipLabel: 'Artist-owned practice · Platform',
       summary:
-        'Artist-owned cultural-technology practice—institutional platforms and the operating name for embedded Digital Lab partnerships (including the Bakehouse conversation).',
+        'Artist-owned cultural-technology practice—institutional platforms and the operating name for embedded Digital Lab partnerships.',
       href: 'https://dcc.miami',
       external: true,
       imageSrc: DCC.imageSrc,
       imageAlt: DCC.imageAlt,
-    },
-    {
-      id: 'knight',
-      name: 'John S. and James L. Knight Foundation',
-      location: 'Miami / national',
-      relationship: 'funder',
-      relationshipLabel: ORG_RELATIONSHIP_LABELS.funder,
-      summary: 'Funder of Oolite Arts Digital Lab; related civic-technology and proposal work archived on site.',
-      href: '/grant/knight-foundation',
-      imageSrc: OOLITE_DIGITAL_LAB_IMAGE,
-      imageAlt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
+      archiveFeatured: true,
     },
     {
       id: 'mdc-idea',
@@ -364,6 +748,18 @@ export const institutionsHub = {
       relationshipLabel: ORG_RELATIONSHIP_LABELS.education,
       summary: 'AI Sprint for Artists — workshop and education partnership.',
       href: '/workshops',
+      archiveFeatured: true,
+    },
+    {
+      id: 'knight',
+      name: 'John S. and James L. Knight Foundation',
+      location: 'Miami / national',
+      relationship: 'funder',
+      relationshipLabel: ORG_RELATIONSHIP_LABELS.funder,
+      summary: 'Funder of Oolite Arts Digital Lab; related civic-technology and proposal work archived on site. Not a direct employer.',
+      href: '/grant/knight-foundation',
+      imageSrc: OOLITE_DIGITAL_LAB_IMAGE,
+      imageAlt: OOLITE_DIGITAL_LAB_IMAGE_ALT,
     },
     {
       id: 'museum-of-sex',
@@ -498,15 +894,11 @@ export const institutionsHub = {
       href: '/workshops',
     },
   ] satisfies InstitutionOrg[],
-  nextSteps: {
-    title: 'How to work together',
-    items: [
-      'Embedded / fractional digital leadership (6–12 months)',
-      'Paid workshop pilots and curriculum collaboration (college, high school, and cultural orgs)',
-      'Artist-facing platforms and institutional workflows',
-      'Creative-technology programming, visiting artist sessions, and production support',
-    ],
-  },
   honestyNote:
-    'Organizations listed above are verified through employment, residency, lab operations, workshops, exhibitions, platform builds, education, or funder credits documented on this site. Application-only relationships (for example YoungArts) are not listed as prior affiliations.',
+    'Listed through employment, residency, lab operations, workshops, exhibitions, platform builds, education, or funder credits documented on this site. Application-only relationships are not listed.',
+  icaNotions: {
+    src: ICA_NOTIONS,
+    alt: 'Notions of Home — later ICA Miami × Dminti exhibition context',
+    caption: 'Later exhibition context — not visual evidence of the 2019–2020 Digital Producer role.',
+  },
 } as const;

--- a/src/content/institutions/icaMiami.ts
+++ b/src/content/institutions/icaMiami.ts
@@ -1,0 +1,66 @@
+/**
+ * /ica-miami — dedicated ICA systems case study.
+ * Facts limited to verified Digital Producer work (Oct 2019–Dec 2020).
+ * Notions of Home is later exhibition context only — not employment proof.
+ */
+
+import { INSTITUTIONAL_CALENDLY_URL, INSTITUTIONAL_EMAIL } from './shared';
+
+const CDN = 'https://res.cloudinary.com/dck5rzi4h/image/upload';
+const ICA_NOTIONS = `${CDN}/v1739483923/art/moisestech-website/exhibitions/dec_2024_dminti_notions_of_home/NotionsOfHome_banner_soubxf.jpg`;
+
+export const icaMiamiPage = {
+  meta: {
+    title: 'ICA Miami — Digital Production Systems | Moises Sanabria',
+    description:
+      'Digital Producer at ICA Miami (2019–2020): Salesforce-to-WordPress workflows, website management, livestreaming, SEO, and vendor coordination for museum public programs.',
+    url: 'https://moises.tech/ica-miami',
+  },
+  hero: {
+    eyebrow: 'ICA Miami · Digital Producer',
+    headline: 'Connecting museum data, public programming, and digital audiences.',
+    lead:
+      'From October 2019 to December 2020 I worked inside ICA Miami as Digital Producer—connecting Salesforce collection data to WordPress and ticketing, maintaining the public site, and producing livestreams and captions for programs that had to reach beyond the building.',
+    dates: 'October 2019 – December 2020',
+    status: 'Employment / operated',
+    availability: 'Currently available for related web, Salesforce, and livestreaming work.',
+  },
+  capabilities: [
+    {
+      title: 'Salesforce → WordPress / ticketing',
+      body: 'Synced the museum’s art collection from Salesforce into WordPress ticketing infrastructure so public pages and registration could stay connected to institutional data.',
+    },
+    {
+      title: 'Website management',
+      body: 'WordPress administration, GitHub workflows, GraphQL, AWS CloudFront, SEO, and ongoing web maintenance.',
+    },
+    {
+      title: 'Vendor coordination',
+      body: 'Managed third-party vendors delivering interactive HTML5 video and web production—reducing the number of handoffs required for public digital work.',
+    },
+    {
+      title: 'Livestreaming and captions',
+      body: 'OBS livestreaming, YouTube, AI-driven subtitling, and After Effects for the Institute’s international music program and remote public programs.',
+    },
+  ],
+  proofSequence: [
+    { stage: 'Need', text: 'Digital autonomy, faster updates, connected collection and program data, remote programs.' },
+    { stage: 'Intervention', text: 'Web and data integration, vendor coordination, streaming workflows, captioning, forms, reporting, and production.' },
+    { stage: 'Adoption', text: 'Cross-department use by development, external affairs, education, curatorial, and programs.' },
+    { stage: 'Capacity', text: 'Lower vendor friction and reusable public-program workflows.' },
+  ],
+  laterContext: {
+    title: 'Later exhibition context',
+    body: 'Notions of Home (ICA Miami × Dminti) is a later exhibition credit. It is cultural context, not visual evidence of the 2019–2020 Digital Producer role.',
+    image: {
+      src: ICA_NOTIONS,
+      alt: 'Notions of Home — ICA Miami × Dminti exhibition banner',
+    },
+    href: '/calendar/exhibitions',
+  },
+  ctas: {
+    primary: { label: 'Discuss a related project', href: INSTITUTIONAL_CALENDLY_URL },
+    email: INSTITUTIONAL_EMAIL,
+    back: { label: 'Institutional technology overview', href: '/institutions' },
+  },
+} as const;

--- a/src/content/institutions/shared.ts
+++ b/src/content/institutions/shared.ts
@@ -16,6 +16,14 @@ export const INSTITUTIONAL_COLLABORATION_AVAILABILITY =
   'Available for paid guest teaching, curriculum development, and institutional creative-technology collaborations beginning fall 2026.';
 
 /**
+ * /institutions services page — current availability for technical review,
+ * focused projects, and fractional digital support. Do not reuse the
+ * teaching-collaboration fall 2026 line on this page.
+ */
+export const INSTITUTIONAL_SERVICES_AVAILABILITY =
+  'Currently available for project-based and fractional engagements.';
+
+/**
  * Oolite case-study context only — not a competing hero availability line.
  * Year-long Technical Director of Digital engagement concludes September 17, 2026.
  */
@@ -68,7 +76,7 @@ export const INSTITUTIONAL_FAMILY_NAV = [
     href: '/institutions',
     label: 'Hub',
     match: 'institutions',
-    short: 'Directory',
+    short: 'Services',
     accent: 'rose',
   },
 ] as const;

--- a/src/content/oolite-arts/media.ts
+++ b/src/content/oolite-arts/media.ts
@@ -47,6 +47,7 @@ export const digilabMedia = {
       '/oolite-arts#before-after',
       '/artist-infrastructure#hero',
       '/artist-infrastructure#oolite-proof',
+      '/institutions#hero',
       'OOLITE_DIGITAL_LAB_IMAGE (shared constant)',
     ],
   },
@@ -67,7 +68,7 @@ export const digilabMedia = {
     alt: 'Oolite Arts Digital Lab — 360° wide room view with workstations',
     category: 'space',
     cloudinaryId: 'oolite-arts/oolite-arts-digital-lab-360-photo_uaguwe',
-    usedOn: ['/oolite-arts#hero-parallax', '/oolite-arts#lab-gallery'],
+    usedOn: ['/oolite-arts#hero-parallax', '/oolite-arts#lab-gallery', '/institutions#banner'],
   },
   'digilab.360-photo-2': {
     id: 'digilab.360-photo-2',
@@ -184,6 +185,7 @@ export const digilabMedia = {
       '/artist-infrastructure#hero',
       '/artist-infrastructure#oolite-proof',
       '/workshop/moonlighter-ai-3d-printing#instructor',
+      '/institutions#hero',
     ],
   },
 
@@ -296,6 +298,7 @@ export const digilabMedia = {
       '/artist-infrastructure#oolite-proof',
       '/workshop/moonlighter-ai-3d-printing#instructor',
       '/workshops#about',
+      '/institutions#profile',
     ],
   },
   'portrait.fabiola': {

--- a/src/features/landing/components/Footer.tsx
+++ b/src/features/landing/components/Footer.tsx
@@ -56,7 +56,7 @@ export default function Footer() {
         </div>
 
         <div className="text-3xl font-extrabold mb-2">Moises</div>
-        <div className="text-base text-gray-300">© 2025 The Studio of Moises Sanabria</div>
+        <div className="text-base text-gray-300">© 2026 The Studio of Moises Sanabria</div>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- Rebuild `/institutions` as a focused services page for museum and arts-organization outreach (web, Salesforce, automation, livestreaming, labs) instead of an archive with parallel outreach and workshop pricing.
- Lead with Oolite, ICA Miami, and Bakehouse as flagship case studies, and add a dedicated ICA systems page at `/ica-miami`.
- Compact the 20-organization directory into a secondary experience archive and replace public workshop rates with three engagement formats (review, focused project, fractional support).

## Test plan
- [ ] Open `/institutions` and confirm 192px top offset, banner, hoverable profile, and software logo band (Salesforce, WordPress, Bloomerang, Airtable, OBS).
- [ ] Confirm Parallel Outreach and `$360–$450` workshop pricing are gone; availability reads “currently available.”
- [ ] Scan the four practice lanes (icons, colors, stack marks, hover “what this solves”).
- [ ] Confirm flagship order is Oolite → ICA → Bakehouse; ICA card links to `/ica-miami`, not `/cv`.
- [ ] Expand “View full experience” and filter the institutional archive.
- [ ] Click sticky “Discuss a project” and engagement CTAs; confirm footer year is 2026.


Made with [Cursor](https://cursor.com)