### PR TITLE
Add application banner and 192px offset to /ica-miami

### DIFF
--- a/src/app/(main)/ica-miami/page.tsx
+++ b/src/app/(main)/ica-miami/page.tsx
@@ -12,6 +12,12 @@ export const metadata: Metadata = {
     description: meta.description,
     type: 'website',
     url: meta.url,
+    images: [
+      {
+        url: icaMiamiPage.banner.src,
+        alt: icaMiamiPage.banner.alt,
+      },
+    ],
   },
   twitter: {
     card: 'summary_large_image',

--- a/src/components/institutions/CompoundingSystem.tsx
+++ b/src/components/institutions/CompoundingSystem.tsx
@@ -9,6 +9,7 @@ import {
   InstReveal,
   InstSectionLabel,
   LANE_ACCENT,
+  INST_ANCHOR_SCROLL_MT_CLASS,
 } from '@/components/institutions/InstitutionalUi';
 import { cn } from '@/lib/utils';
 
@@ -16,7 +17,7 @@ export function InstitutionalProofStrip() {
   return (
     <section
       id="proof"
-      className="scroll-mt-32 border-b border-neutral-200 py-10 sm:py-12"
+      className={cn(INST_ANCHOR_SCROLL_MT_CLASS, 'border-b border-neutral-200 py-10 sm:py-12')}
       aria-labelledby="proof-heading"
     >
       <InstContainer>
@@ -72,7 +73,7 @@ export function CompoundingSystem() {
   return (
     <section
       id="system"
-      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      className={cn(INST_ANCHOR_SCROLL_MT_CLASS, 'border-b border-neutral-200 py-16 sm:py-20')}
       aria-labelledby="system-heading"
     >
       <InstContainer>

--- a/src/components/institutions/EngagementModes.tsx
+++ b/src/components/institutions/EngagementModes.tsx
@@ -10,7 +10,9 @@ import {
   InstReveal,
   InstSecondaryCta,
   InstSectionLabel,
+  INST_ANCHOR_SCROLL_MT_CLASS,
 } from '@/components/institutions/InstitutionalUi';
+import { cn } from '@/lib/utils';
 
 const PROCESS_ICON: Record<(typeof H.process.steps)[number]['icon'], LucideIcon> = {
   search: Search,
@@ -22,7 +24,7 @@ export function ProcessSteps() {
   return (
     <section
       id="process"
-      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      className={cn(INST_ANCHOR_SCROLL_MT_CLASS, 'border-b border-neutral-200 py-16 sm:py-20')}
       aria-labelledby="process-heading"
     >
       <InstContainer>
@@ -70,7 +72,7 @@ export function EngagementModes() {
   return (
     <section
       id="engage"
-      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      className={cn(INST_ANCHOR_SCROLL_MT_CLASS, 'border-b border-neutral-200 py-16 sm:py-20')}
       aria-labelledby="engage-heading"
     >
       <InstContainer>

--- a/src/components/institutions/FlagshipCaseStudies.tsx
+++ b/src/components/institutions/FlagshipCaseStudies.tsx
@@ -11,6 +11,7 @@ import {
   InstReveal,
   InstSectionLabel,
   LANE_ACCENT,
+  INST_ANCHOR_SCROLL_MT_CLASS,
 } from '@/components/institutions/InstitutionalUi';
 import { IcaSystemsDiagram } from '@/components/institutions/IcaSystemsDiagram';
 import { cn } from '@/lib/utils';
@@ -40,7 +41,7 @@ export function FlagshipCaseStudies() {
   return (
     <section
       id="work"
-      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      className={cn(INST_ANCHOR_SCROLL_MT_CLASS, 'border-b border-neutral-200 py-16 sm:py-20')}
       aria-labelledby="work-heading"
     >
       <InstContainer>
@@ -62,7 +63,7 @@ export function FlagshipCaseStudies() {
               <InstReveal key={study.id}>
                 <article
                   id={`work-${study.id}`}
-                  className="scroll-mt-32 border border-neutral-200 bg-white"
+                  className={cn(INST_ANCHOR_SCROLL_MT_CLASS, 'border border-neutral-200 bg-white')}
                 >
                   <div className={cn('grid lg:grid-cols-12', reverse && 'lg:[&>*:first-child]:order-2')}>
                     <div className="relative min-h-[240px] bg-neutral-100 lg:col-span-5">
@@ -166,7 +167,7 @@ export function AdditionalEvidence() {
   return (
     <section
       id="evidence"
-      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      className={cn(INST_ANCHOR_SCROLL_MT_CLASS, 'border-b border-neutral-200 py-16 sm:py-20')}
       aria-labelledby="evidence-heading"
     >
       <InstContainer>

--- a/src/components/institutions/IcaMiamiPageClient.tsx
+++ b/src/components/institutions/IcaMiamiPageClient.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { icaMiamiPage as P } from '@/content/institutions/icaMiami';
+import { OpportunityApplicationBanner } from '@/components/opportunities/OpportunityApplicationBanner';
 import { track } from '@/lib/analytics';
 import {
   InstContainer,
@@ -18,6 +19,12 @@ import { IcaSystemsDiagram } from '@/components/institutions/IcaSystemsDiagram';
 export function IcaMiamiPageClient() {
   return (
     <InstPageShell className="pt-[192px]">
+      <OpportunityApplicationBanner banner={P.banner} className="mb-0" />
+      {P.bannerNote ? (
+        <p className="border-b border-neutral-200 bg-amber-50/80 px-4 py-2 text-center font-mono text-[10px] uppercase tracking-[0.14em] text-amber-950 sm:px-6">
+          {P.bannerNote}
+        </p>
+      ) : null}
       <InstFamilyNav active="institutions" className="sticky top-0 z-40" />
       <header className="border-b border-neutral-200">
         <InstContainer className="py-14 sm:py-20">

--- a/src/components/institutions/InstitutionArchive.tsx
+++ b/src/components/institutions/InstitutionArchive.tsx
@@ -15,6 +15,7 @@ import {
   InstContainer,
   InstReveal,
   InstSectionLabel,
+  INST_ANCHOR_SCROLL_MT_CLASS,
 } from '@/components/institutions/InstitutionalUi';
 import { cn } from '@/lib/utils';
 
@@ -50,7 +51,7 @@ export function InstitutionArchive() {
   return (
     <section
       id="archive"
-      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      className={cn(INST_ANCHOR_SCROLL_MT_CLASS, 'border-b border-neutral-200 py-16 sm:py-20')}
       aria-labelledby="archive-heading"
     >
       <InstContainer>

--- a/src/components/institutions/InstitutionalUi.tsx
+++ b/src/components/institutions/InstitutionalUi.tsx
@@ -137,6 +137,21 @@ export const LANE_ACCENT = {
   lab: 'copper',
 } as const satisfies Record<string, keyof typeof INST_ACCENT>;
 
+/**
+ * Site header is `fixed` (expanded ≈ 192px / 12rem, collapses to 80px).
+ * Family nav must stick *below* that live height — never `top-0`.
+ */
+export const INST_FAMILY_STICKY_CLASS =
+  'sticky z-40 top-[var(--site-header-height,12rem)] transition-[top] duration-300 ease-in-out';
+
+/** Page-section chips sit under the family strip (~3.75rem). */
+export const INST_SECTION_STICKY_CLASS =
+  'sticky z-30 top-[calc(var(--site-header-height,12rem)+3.75rem)] transition-[top] duration-300 ease-in-out';
+
+/** Anchor offset: live header + family nav + section nav. */
+export const INST_ANCHOR_SCROLL_MT_CLASS =
+  'scroll-mt-[calc(var(--site-header-height,12rem)+7.5rem)]';
+
 const FAMILY_ICONS: Record<InstitutionalFamilyMatch, LucideIcon> = {
   'artist-infrastructure': Network,
   institutions: LayoutGrid,

--- a/src/components/institutions/InstitutionsFinalCTA.tsx
+++ b/src/components/institutions/InstitutionsFinalCTA.tsx
@@ -7,13 +7,15 @@ import {
   InstContainer,
   InstReveal,
   InstSecondaryCta,
+  INST_ANCHOR_SCROLL_MT_CLASS,
 } from '@/components/institutions/InstitutionalUi';
+import { cn } from '@/lib/utils';
 
 export function InstitutionsFinalCTA() {
   return (
     <section
       id="contact"
-      className="scroll-mt-32 bg-neutral-950 py-16 text-white sm:py-20"
+      className={cn(INST_ANCHOR_SCROLL_MT_CLASS, 'bg-neutral-950 py-16 text-white sm:py-20')}
       aria-labelledby="contact-heading"
     >
       <InstContainer>

--- a/src/components/institutions/InstitutionsHero.tsx
+++ b/src/components/institutions/InstitutionsHero.tsx
@@ -11,13 +11,14 @@ import {
   InstPrimaryCta,
   InstSecondaryCta,
   InstSectionLabel,
+  INST_ANCHOR_SCROLL_MT_CLASS,
 } from '@/components/institutions/InstitutionalUi';
 
 export function InstitutionsHero() {
   const { collage } = H.hero;
 
   return (
-    <header id="top" className="scroll-mt-32 border-b border-neutral-200">
+    <header id="top" className={`${INST_ANCHOR_SCROLL_MT_CLASS} border-b border-neutral-200`}>
       <InstContainer className="py-12 sm:py-16 md:py-20">
         <div className="grid items-start gap-10 lg:grid-cols-12 lg:gap-12">
           <div className="lg:col-span-7">

--- a/src/components/institutions/InstitutionsHubClient.tsx
+++ b/src/components/institutions/InstitutionsHubClient.tsx
@@ -8,6 +8,8 @@ import {
   InstContainer,
   InstFamilyNav,
   InstPageShell,
+  INST_FAMILY_STICKY_CLASS,
+  INST_SECTION_STICKY_CLASS,
 } from '@/components/institutions/InstitutionalUi';
 import { OpportunityApplicationBanner } from '@/components/opportunities/OpportunityApplicationBanner';
 import { InstitutionsHero } from '@/components/institutions/InstitutionsHero';
@@ -77,10 +79,13 @@ export function InstitutionsHubClient() {
         </p>
       ) : null}
 
-      <InstFamilyNav active="institutions" className="sticky top-0 z-40" />
+      <InstFamilyNav active="institutions" className={INST_FAMILY_STICKY_CLASS} />
 
       <nav
-        className="sticky top-[45px] z-30 border-b border-neutral-200 bg-[#f7f6f3]/90 backdrop-blur"
+        className={cn(
+          INST_SECTION_STICKY_CLASS,
+          'border-b border-neutral-200 bg-[#f7f6f3]/90 backdrop-blur',
+        )}
         aria-label="Page sections"
       >
         <InstContainer className="flex items-center gap-2 py-2">

--- a/src/components/institutions/PracticeLaneGrid.tsx
+++ b/src/components/institutions/PracticeLaneGrid.tsx
@@ -17,6 +17,7 @@ import {
   InstReveal,
   InstSectionLabel,
   LANE_ACCENT,
+  INST_ANCHOR_SCROLL_MT_CLASS,
 } from '@/components/institutions/InstitutionalUi';
 import { LaneStackVisual } from '@/components/institutions/IcaSystemsDiagram';
 import { cn } from '@/lib/utils';
@@ -39,7 +40,7 @@ export function PracticeLaneGrid() {
   return (
     <section
       id="services"
-      className="scroll-mt-32 border-b border-neutral-200 py-16 sm:py-20"
+      className={cn(INST_ANCHOR_SCROLL_MT_CLASS, 'border-b border-neutral-200 py-16 sm:py-20')}
       aria-labelledby="lanes-heading"
     >
       <InstContainer>

--- a/src/components/opportunities/OpportunityApplicationBanner.tsx
+++ b/src/components/opportunities/OpportunityApplicationBanner.tsx
@@ -113,7 +113,12 @@ function BannerLayer({
   if (isSvgLocal) {
     return (
       // eslint-disable-next-line @next/next/no-img-element
-      <img src={src} alt={alt} className={cn('h-full w-full object-cover', coverPos, className)} />
+      <img
+        src={src}
+        alt={alt}
+        className={cn('h-full w-full object-cover', coverPos, className)}
+        style={{ objectPosition: objectPosition === 'center' ? 'center' : 'top' }}
+      />
     );
   }
 
@@ -123,6 +128,7 @@ function BannerLayer({
       alt={alt}
       fill
       className={cn('object-cover', coverPos, className)}
+      style={{ objectPosition: objectPosition === 'center' ? 'center' : 'top' }}
       sizes="100vw"
       priority={priority}
     />

--- a/src/components/opportunities/OpportunityApplicationBanner.tsx
+++ b/src/components/opportunities/OpportunityApplicationBanner.tsx
@@ -28,6 +28,7 @@ type BannerLayerProps = {
   intrinsicRatio?: number;
   className?: string;
   priority?: boolean;
+  objectPosition?: 'center' | 'top';
 };
 
 function BannerLayer({
@@ -38,8 +39,10 @@ function BannerLayer({
   intrinsicRatio,
   className,
   priority,
+  objectPosition = 'top',
 }: BannerLayerProps) {
   const isSvgLocal = !remote && src.endsWith('.svg');
+  const coverPos = objectPosition === 'center' ? 'object-center' : 'object-top';
 
   if (presentation === 'contain-blur') {
     return (
@@ -110,7 +113,7 @@ function BannerLayer({
   if (isSvgLocal) {
     return (
       // eslint-disable-next-line @next/next/no-img-element
-      <img src={src} alt={alt} className={cn('h-full w-full object-cover object-top', className)} />
+      <img src={src} alt={alt} className={cn('h-full w-full object-cover', coverPos, className)} />
     );
   }
 
@@ -119,7 +122,7 @@ function BannerLayer({
       src={src}
       alt={alt}
       fill
-      className={cn('object-cover object-top', className)}
+      className={cn('object-cover', coverPos, className)}
       sizes="100vw"
       priority={priority}
     />
@@ -167,6 +170,7 @@ export function OpportunityApplicationBanner({ banner, className }: OpportunityA
               remote={remote}
               presentation={presentation}
               intrinsicRatio={banner.intrinsicRatio}
+              objectPosition={banner.objectPosition}
               className="sm:hidden"
               priority
             />
@@ -176,6 +180,7 @@ export function OpportunityApplicationBanner({ banner, className }: OpportunityA
               remote
               presentation={presentation}
               intrinsicRatio={banner.intrinsicRatio}
+              objectPosition={banner.objectPosition}
               className="hidden sm:block lg:hidden"
               priority
             />
@@ -185,6 +190,7 @@ export function OpportunityApplicationBanner({ banner, className }: OpportunityA
               remote
               presentation={presentation}
               intrinsicRatio={banner.intrinsicRatio}
+              objectPosition={banner.objectPosition}
               className="hidden lg:block"
               priority
             />
@@ -197,6 +203,7 @@ export function OpportunityApplicationBanner({ banner, className }: OpportunityA
               remote={remote}
               presentation={presentation}
               intrinsicRatio={banner.intrinsicRatio}
+              objectPosition={banner.objectPosition}
               className="sm:hidden"
               priority
             />
@@ -206,6 +213,7 @@ export function OpportunityApplicationBanner({ banner, className }: OpportunityA
               remote
               presentation={presentation}
               intrinsicRatio={banner.intrinsicRatio}
+              objectPosition={banner.objectPosition}
               className="hidden sm:block"
               priority
             />
@@ -217,6 +225,7 @@ export function OpportunityApplicationBanner({ banner, className }: OpportunityA
             remote={remote}
             presentation={presentation}
             intrinsicRatio={banner.intrinsicRatio}
+            objectPosition={banner.objectPosition}
             priority
           />
         )}

--- a/src/content/evidence/applicationBanners.ts
+++ b/src/content/evidence/applicationBanners.ts
@@ -184,6 +184,18 @@ export const institutionsDigitalSystemsBanner = defineApplicationBanner({
   frameClass: FLAGSHIP_BANNER_FRAME,
 });
 
+/**
+ * /ica-miami — wide ICA exhibition still as page chrome.
+ * Later-context only: not visual evidence of the 2019–2020 Digital Producer role.
+ */
+export const icaMiamiSystemsBanner = defineApplicationBanner({
+  src: `${cdn}/v1739483923/art/moisestech-website/exhibitions/dec_2024_dminti_notions_of_home/NotionsOfHome_banner_soubxf.jpg`,
+  alt: 'Notions of Home — ICA Miami × Dminti exhibition banner',
+  intrinsicRatio: 21 / 9,
+  presentation: 'cover',
+  frameClass: FLAGSHIP_BANNER_FRAME,
+});
+
 /** Morley — Art Director (Remote, Florida). */
 export const morleyArtDirectorBanner = defineApplicationBanner({
   src: `${cdn}/v1785862415/jobs/banners/art-director-morley-banner_b5ridm.png`,

--- a/src/content/evidence/applicationBanners.ts
+++ b/src/content/evidence/applicationBanners.ts
@@ -28,6 +28,7 @@ type BannerInput = {
   presentation?: ApplicationBanner['presentation'];
   aspectClass?: string;
   frameClass?: string;
+  objectPosition?: ApplicationBanner['objectPosition'];
 };
 
 /** Prefer this helper so every banner declares its intrinsic width÷height. */
@@ -41,6 +42,7 @@ export function defineApplicationBanner(input: BannerInput): ApplicationBanner {
     presentation: input.presentation ?? 'contain-blur',
     aspectClass: input.aspectClass,
     frameClass: input.frameClass,
+    objectPosition: input.objectPosition,
   };
 }
 
@@ -182,6 +184,7 @@ export const institutionsDigitalSystemsBanner = defineApplicationBanner({
   intrinsicRatio: 16 / 9,
   presentation: 'cover',
   frameClass: FLAGSHIP_BANNER_FRAME,
+  objectPosition: 'center',
 });
 
 /**

--- a/src/content/institutions/icaMiami.ts
+++ b/src/content/institutions/icaMiami.ts
@@ -4,6 +4,7 @@
  * Notions of Home is later exhibition context only — not employment proof.
  */
 
+import { icaMiamiSystemsBanner } from '@/content/evidence/applicationBanners';
 import { INSTITUTIONAL_CALENDLY_URL, INSTITUTIONAL_EMAIL } from './shared';
 
 const CDN = 'https://res.cloudinary.com/dck5rzi4h/image/upload';
@@ -16,6 +17,8 @@ export const icaMiamiPage = {
       'Digital Producer at ICA Miami (2019–2020): Salesforce-to-WordPress workflows, website management, livestreaming, SEO, and vendor coordination for museum public programs.',
     url: 'https://moises.tech/ica-miami',
   },
+  banner: icaMiamiSystemsBanner,
+  bannerNote: null as string | null,
   hero: {
     eyebrow: 'ICA Miami · Digital Producer',
     headline: 'Connecting museum data, public programming, and digital audiences.',

--- a/src/content/opportunities/types.ts
+++ b/src/content/opportunities/types.ts
@@ -40,6 +40,11 @@ export type ApplicationBanner = {
    * `cover`: legacy full-bleed crop — only for assets designed to survive edge crop.
    */
   presentation?: 'contain-blur' | 'cover';
+  /**
+   * Cover-crop focal point. Default `top` matches recruiting banners.
+   * Use `center` for cinematic stills that should stay vertically aligned in the strip.
+   */
+  objectPosition?: 'center' | 'top';
 };
 
 export type OpportunityStatus = 'active' | 'draft';


### PR DESCRIPTION
## Summary
- Add the shared full-width application banner to `/ica-miami`, matching `/institutions` chrome.
- Keep the 192px top offset so the page clears the site header, with the banner above the family nav.

## Test plan
- [ ] Open `/ica-miami` and confirm 192px clearance above the banner.
- [ ] Confirm the banner strip appears before the institutions family nav.
- [ ] Confirm the rest of the ICA case study (diagram, capabilities, later exhibition context) is unchanged.


Made with [Cursor](https://cursor.com)